### PR TITLE
Issue with local plugins

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -47,6 +47,7 @@ func! s:parse_name(arg)
   elseif arg =~ '^\s*\(git@\|git://\)\S\+' 
   \   || arg =~ 'https\?://'
   \   || arg =~ '\.git\s*$'
+  \   || arg =~ '\(file://\)\?[~/]'
     let uri = arg
     let name = substitute(split(uri,'\/')[-1], '\.git\s*$','','i')
   else


### PR DESCRIPTION
The regex for the repo URL did only match the right case when the directory ended in .git
Now it looks for a possible "file://" and matches on leading "~" and "/".

closes gmarik/vundle#9
