### PR TITLE
corrected path used for :helptags instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Also [Vundle]:
 
 ## Docs
 
-run [`:helptags ~/.vim/vundle.git/doc`](https://github.com/gmarik/vundle/issues/17)
+run [`:helptags ~/.vim/bundle/vundle/doc`](https://github.com/gmarik/vundle/issues/17)
 
 see [`:h vundle`](vundle/blob/master/doc/vundle.txt#L1) vimdoc for more details.
 


### PR DESCRIPTION
corrected path used for :helptags instructions to be inline with directory structure used in installation instructions.
