### PR TITLE
README: highlight syntax in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,42 @@
 
 1. Setup [Vundle]:
 
-        git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+```console
+$ git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+```
 
 2. Configure bundles:
 
       Sample `.vimrc`:
 
-        set nocompatible               " be iMproved
-        filetype off                   " required!
+```vim
+set nocompatible               " be iMproved
+filetype off                   " required!
 
-        set rtp+=~/.vim/bundle/vundle/
-        call vundle#rc()
+set rtp+=~/.vim/bundle/vundle/
+call vundle#rc()
 
-        " let Vundle manage Vundle
-        Bundle 'gmarik/vundle'
+" let Vundle manage Vundle
+Bundle 'gmarik/vundle'
 
-        " My Bundles here:
-        "
-        " original repos on github
-        Bundle 'tpope/vim-fugitive'
-        Bundle 'lokaltog/vim-easymotion'
-        Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
-        " vim-scripts repos
-        Bundle 'L9'
-        Bundle 'FuzzyFinder'
-        Bundle 'rails.vim'
-        " non github repos
-        Bundle 'git://git.wincent.com/command-t.git'
-        " ...
+" My Bundles here:
+"
+" original repos on github
+Bundle 'tpope/vim-fugitive'
+Bundle 'lokaltog/vim-easymotion'
+Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
+" vim-scripts repos
+Bundle 'L9'
+Bundle 'FuzzyFinder'
+Bundle 'rails.vim'
+" non github repos
+Bundle 'git://git.wincent.com/command-t.git'
+" ...
 
-        filetype plugin indent on     " required! 
-        " or 
-        " filetype plugin on          " to not use the indentation settings set by plugins
+filetype plugin indent on     " required! 
+" or 
+" filetype plugin on          " to not use the indentation settings set by plugins
+```
 
 3. Install configured bundles:
 
@@ -79,11 +83,13 @@ see [`:h vundle`](vundle/blob/master/doc/vundle.txt#L1) vimdoc for more details.
 
     **A** This is the case of invalid name used with `Bundle`, which leads to attempt to clone nonexisting repo:
 
-        git clone http://github.com/gmarik/non_existin_repo
-        Cloning into non_existin_repo...
-        Username: 
-        Password: 
-        fatal: Authentication failed
+    ```console
+    $ git clone http://github.com/gmarik/non_existin_repo
+    Cloning into non_existin_repo...
+    Username: 
+    Password: 
+    fatal: Authentication failed
+    ```
 
 
 -   **Q** My configuration is bundle dependant, so when I try to install plugins for the first time I get errors. How do I fix that?


### PR DESCRIPTION
GitHub supports highlighting of syntax in code block for Markdown, though I couldn't get it to play nice with the indentation to make the blocks part of the lists. Merge according to preference.
