### PR TITLE
Allow comments after Bundle declarations

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -4,7 +4,7 @@
 " Readme:       http://github.com/gmarik/vundle/blob/master/README.md
 " Version:      0.8
 
-com! -nargs=+         Bundle
+com! -nargs=+ -bar    Bundle
 \ call vundle#config#bundle(<args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall


### PR DESCRIPTION
As far as I can tell (as explained by `:help command-bar`), the only downside to this is:

> A "|" inside the command argument is not allowed then.

which shouldn't pose any problems.
