### PR TITLE
Add filetype on in readme with OS X note. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
      ```vim
      set nocompatible               " be iMproved
+     filetype on                    " required on OS X!
      filetype off                   " required!
 
      set rtp+=~/.vim/bundle/vundle/


### PR DESCRIPTION
Apparently the default vim in OS X will exit 1 after editing if you try to `filetype off` before you `filetype on`
