### PR TITLE
Adds support for Launchpad repos

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -40,6 +40,7 @@ endf
 
 func! s:parse_name(arg)
   let arg = a:arg
+  let vcs = 'git'
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
     let uri = 'https://github.com/'.split(arg, ':')[-1]
@@ -49,11 +50,15 @@ func! s:parse_name(arg)
   \   || arg =~? '\.git\s*$'
     let uri = arg
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
+  elseif arg =~? '^lp:'
+    let uri = arg
+	let name = split (uri, ':')[-1]
+	let vcs = 'bzr'
   else
     let name = arg
     let uri  = 'https://github.com/vim-scripts/'.name.'.git'
   endif
-  return {'name': name, 'uri': uri }
+  return {'name': name, 'uri': uri, 'vcs': vcs }
 endf
 
 func! s:rtp_rm_a()

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -66,17 +66,17 @@ func! s:helptags(rtp) abort
 endf
 
 func! s:sync(bang, bundle) abort
-  let git_dir = expand(a:bundle.path().'/.git/')
-  if isdirectory(git_dir)
+  let repo_dir = expand(a:bundle.path().'/.'.a:bundle.vcs.'/')
+  if isdirectory(repo_dir)
     if !(a:bang) | return 0 | endif
-    let cmd = 'cd '.shellescape(a:bundle.path()).' && git pull'
+    let cmd = 'cd '.shellescape(a:bundle.path()).' && '.a:bundle.vcs.' pull'
 
     if (has('win32') || has('win64'))
       let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
       let cmd = '"'.cmd.'"'                          " enclose in quotes
     endif
   else
-    let cmd = 'git clone '.a:bundle.uri.' '.shellescape(a:bundle.path())
+    let cmd = a:bundle.vcs.' clone '.a:bundle.uri.' '.shellescape(a:bundle.path())
   endif
   silent exec '!'.cmd
   return 1


### PR DESCRIPTION
I added this because I use some really good plugins that are primarily hosted on Launchpad, e.g. UltiSnips. Of course, Vim-Scripts mirrors vim.org and there are clones of various plugins on Github that are hosted elsewhere. But Vim-scripts only hosts proper releases, and other clones are often unofficial and not updated.

The changes are really small. I've added more note on the commit itself. Check it out.

Perhaps this doesn't properly "blend in" with the goals of Vundle, so feel free to deny this pull request if you feel this clutters things. I must admit that the reason for adding it is perhaps a bit shallow.
