### PR TITLE
Branch Nin: Adding .git to uris although github lets you clone without them

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -44,6 +44,9 @@ func! s:parse_name(arg)
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
     let uri = 'https://github.com/'.split(arg, ':')[-1]
+    if uri !~? '\.git$'
+      let uri .= '.git'
+    endif
     let name = substitute(split(uri,'\/')[-1], '\.git\s*$','','i')
   elseif arg =~? '^\s*\(git@\|git://\)\S\+' 
   \   || arg =~? '\(file\|https\?\)://'


### PR DESCRIPTION
Uris for repos specified as `user/repo` end up being `https://github.com/user/repo` (no trailing `.git`). For some reason, github allows cloning from such uris, however, it is better to rely on the addresses that github provide for cloning, and those include the trailing `.git`.

This change appends .git to github repo uris when needed.
