### PR TITLE
Marking the installer buffer as not modified

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -57,6 +57,7 @@ func! vundle#installer#install(bang, name) abort
   else
     throw 'whoops, unknown status:'.status
   endif
+  set nomodified
 endf
 
 func! vundle#installer#helptags(bundles) abort


### PR DESCRIPTION
Installer buffer is marked as modified after each installation. Mark it
as nomodified so that no warnings are shown when the buffer is closed.

I am doing it once per bundle in case the user aborts the installation, i.e., CTRL-C. This solves one of the issues in gmarik/vundle#69
