### PR TITLE
Nin: Use only already loaded Bundles for installation, do not source vimrc again

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -1,6 +1,6 @@
 func! vundle#installer#new(bang, ...) abort
   let bundles = (a:1 == '') ?
-        \ s:reload_bundles() :
+        \ g:bundles :
         \ map(copy(a:000), 'vundle#config#init_bundle(v:val, {})')
 
   let names = map(copy(bundles), 'v:val.name_spec')


### PR DESCRIPTION
BundleInstall sources the current vimrc in order to reload all Bundles
in order to consider new Bundles that might have been added by the user
directly on their vimrc file. This, however, should not be Vundle's
responsibility, changes in vimrc should not be applied unless it is
re-sourced explicitly by the user.

This makes Vundle use the known list of Bundles for installation.
