### PR TITLE
initial stab at BundleCommand

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -7,6 +7,9 @@
 com! -nargs=+         Bundle
 \ call vundle#config#bundle(<args>)
 
+com! -nargs=1 BundleCommand
+\ call vundle#installer#command(<args>)
+
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall
 \ call vundle#installer#new('!' == '<bang>', <q-args>)
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -11,6 +11,10 @@ func! vundle#installer#new(bang, ...) abort
   call vundle#config#require(bundles)
 endf
 
+func! vundle#installer#command(cmd)
+  silent execute '!cd ~/.vim/bundle && ' . a:cmd
+  redraw!
+endf
 
 func! s:process(bang, cmd)
   let msg = ''


### PR DESCRIPTION
This almost works...   All BundleCommands run every time Vim starts, not just after bundles have been installed.  Running every time Vim starts would be far too slow.

Any idea how to solve this?

Originally I thought BundleCommand should be associated with the previous Bundle and only run if the bundle it's associated with is updated.  So, for example...

```
Bundle 'git://git.wincent.com/command-t.git'
# ensure we compile with system Ruby
BundleCommand 'cd command-t && if which rvm >/dev/null 2>&1; then rvm system exec rake make; else rake make; fi'
```

When command-t gets updated, the BundleCommand would be run.

Now I'm thinking that's too complex, and all BundleCommands should be run after any plugin(s) are installed.  Easier to code, easier to understand.
