### PR TITLE
https:// to git://

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -43,7 +43,7 @@ func! s:parse_name(arg)
 
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
-    let uri = 'https://github.com/'.split(arg, ':')[-1]
+    let uri = 'git://github.com/'.split(arg, ':')[-1]
     if uri !~? '\.git$'
       let uri .= '.git'
     endif


### PR DESCRIPTION
Some of the environments I work in do not have git compiled with libcurl-devel and therefore cannot talk to https. Since vundle seems to only pull repos from git, is it possible to use git:// (read-only) instead of https?
