### PR TITLE
Minor annoyances

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -139,7 +139,7 @@ func! vundle#installer#clean(bang) abort
   call vundle#scripts#view('clean', headers, names)
   redraw
 
-  if (a:bang || empty(names) || input('Continue ? [ y/n ]:') =~? 'y')
+  if (a:bang || empty(names) || input('Continue? [y/n]: ') =~? 'y')
     call s:process(a:bang, 'D')
   endif
 endf


### PR DESCRIPTION
This is a set of small changes to clean up a few things that have been bugging me.

The most significant change is that `BundleClean` now treats blank input as a 'y'.  This same change also wraps the `input()` call in `inputsave()` and `inputrestore()` to prevent mappings from breaking if someone happened to map `BundleClean` for some odd reason.
