### PR TITLE
Proper handling for the case when ~/.vim is under source control

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -174,9 +174,12 @@ func! vundle#installer#delete(bang, dir_name) abort
     let relative_path = prefix.substitute(bundle.path(), g:bundle_dir.'/', '', '')
 
     let cmd = 'cd '.shellescape(top_level)
-    let cmd .= '; git config -f .git/config --remove-section submodule.'.shellescape(relative_path)
     let cmd .= '; git config -f .gitmodules --remove-section submodule.'.shellescape(relative_path)
-    let cmd .= '; git rm --cached '.shellescape(relative_path).'; '
+    let cmd .= '; git config -f .git/config --remove-section submodule.'.shellescape(relative_path)
+    let cmd .= '; git rm --cached '.shellescape(relative_path)
+    let cmd .= '; rm -rf '.shellescape(relative_path)
+    let cmd .= '; rm -rf '.shellescape('.git/modules/'.relative_path)
+    let cmd .= ';'
   endif
 
   let cmd .= (has('win32') || has('win64')) ?

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -278,7 +278,9 @@ func! vundle#installer#relative_path(bundle) abort
   let cmd = vundle#installer#shellesc_cd(cmd)
   let prefix = s:strip(s:system(cmd))
   let pattern = '\V'.substitute(g:bundle_dir, '\\', '\\\\', 'g')
-  return prefix.substitute(a:bundle.path(), pattern, '', '')
+  let suffix = substitute(a:bundle.path(), pattern, '', '')
+  let suffix = substitute(suffix, '^\\', '', '')
+  return prefix.suffix
 endf
 
 " ---------------------------------------------------------------------------

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -291,9 +291,9 @@ func! vundle#installer#delete(bang, dir_name) abort
     let relative_path  = vundle#installer#relative_path(bundle)
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(top_level_path),
+                \ 'git rm --cached '.vundle#installer#shellesc(relative_path),
                 \ 'git config -f .gitmodules --remove-section submodule.'.vundle#installer#shellesc(relative_path),
                 \ 'git config -f .git/config --remove-section submodule.'.vundle#installer#shellesc(relative_path),
-                \ 'git rm --cached '.vundle#installer#shellesc(relative_path),
                 \ 'rm -rf '.vundle#installer#shellesc(relative_path),
                 \ 'rm -rf '.vundle#installer#shellesc('.git/modules/'.relative_path),
                 \ ]

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -202,7 +202,15 @@ func! s:sync(bang, bundle) abort
       let cmd = '"'.cmd.'"'                          " enclose in quotes
     endif
   else
-    let cmd = 'git clone '.a:bundle.uri.' '.shellescape(a:bundle.path())
+    call s:system('cd '.shellescape(g:bundle_dir).'; git status')
+    if v:shell_error
+      let cmd = 'git clone '.a:bundle.uri.' '.shellescape(a:bundle.path())
+    else
+      let top_level = substitute(s:system('cd '.shellescape(g:bundle_dir).'; git rev-parse --show-toplevel'), '\n', '', 'g')
+      let prefix    = substitute(s:system('cd '.shellescape(g:bundle_dir).'; git rev-parse --show-prefix'), '\n', '', 'g')
+      let relative_path = prefix.substitute(a:bundle.path(), g:bundle_dir.'/', '', '')
+      let cmd = 'cd '.shellescape(top_level).'; git submodule add '.a:bundle.uri.' '.shellescape(relative_path)
+    endif
   endif
 
   let out = s:system(cmd)

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -277,7 +277,8 @@ func! vundle#installer#relative_path(bundle) abort
   let cmd = 'cd '.vundle#installer#shellesc(g:bundle_dir).' && git rev-parse --show-prefix'
   let cmd = vundle#installer#shellesc_cd(cmd)
   let prefix = s:strip(s:system(cmd))
-  return prefix.substitute(a:bundle.path(), g:bundle_dir, '', '')
+  let pattern = '\V'.substitute(g:bundle_dir, '\\', '\\\\', 'g')
+  return prefix.substitute(a:bundle.path(), pattern, '', '')
 endf
 
 " ---------------------------------------------------------------------------

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -445,7 +445,7 @@ func! s:make_sync_command(bang, bundle) abort
       let relative_path  = vundle#installer#relative_path(a:bundle)
       let cmd_parts = [
                   \ 'cd '.vundle#installer#shellesc(top_level_path),
-                  \ 'git submodule add '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(relative_path),
+                  \ 'git submodule add -f '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(relative_path),
                   \ 'git submodule init',
                   \ ]
       let cmd = join(cmd_parts, ' && ')

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -307,11 +307,9 @@ func! vundle#installer#delete(bang, dir_name) abort
                 \ ]
     let cmd = join(cmd_parts, ' && ')
     let cmd = vundle#installer#shellesc_cd(cmd)
-    let cmd .= ' &&'
+  else
+    let cmd .= vundle#installer#shell_rmdir(bundle.path())
   endif
-
-  let bundle = vundle#config#init_bundle(a:dir_name, {})
-  let cmd .= vundle#installer#shell_rmdir(bundle.path())
 
   let out = s:system(cmd)
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -540,7 +540,7 @@ func! vundle#installer#shell_rmdir(target) abort
     let cmd = 'rm -rf'
   endif
 
-  return cmd.' '.vundle#installer#shellesc(target)
+  return cmd.' '.vundle#installer#shellesc(a:target)
 endf
 
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -209,7 +209,7 @@ func! s:sync(bang, bundle) abort
       let top_level = substitute(s:system('cd '.shellescape(g:bundle_dir).'; git rev-parse --show-toplevel'), '\n', '', 'g')
       let prefix    = substitute(s:system('cd '.shellescape(g:bundle_dir).'; git rev-parse --show-prefix'), '\n', '', 'g')
       let relative_path = prefix.substitute(a:bundle.path(), g:bundle_dir.'/', '', '')
-      let cmd = 'cd '.shellescape(top_level).'; git submodule add '.a:bundle.uri.' '.shellescape(relative_path)
+      let cmd = 'cd '.shellescape(top_level).'; git submodule add '.a:bundle.uri.' '.shellescape(relative_path).'; git submodule init'
     endif
   endif
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -221,7 +221,7 @@ func! s:sync(bang, bundle) abort
     let relative_path = prefix.substitute(a:bundle.path(), g:bundle_dir.'/', '', '')
     if isdirectory(git_dir)
       if !(a:bang) | return 'todate' | endif
-      let cmd = 'cd '.shellescape(top_level).' && git submodule update '.shellescape(relative_path)
+      let cmd = 'cd '.shellescape(top_level).' && git submodule update --merge '.shellescape(relative_path)
     else
       let cmd = 'cd '.shellescape(top_level).' && git submodule add '.a:bundle.uri.' '.shellescape(relative_path).' && git submodule init'
     endif

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -432,7 +432,8 @@ func! s:make_sync_command(bang, bundle) abort
 
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
-                \ 'git pull',
+                \ 'git fetch',
+                \ 'git reset --hard origin/HEAD',
                 \ 'git submodule update --init --merge --recursive',
                 \ ]
     let cmd = join(cmd_parts, ' && ')

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -268,11 +268,11 @@ func! vundle#installer#top_level_path() abort
   return out
 endf
 
-func! vundle#installer#relative_path() abort
+func! vundle#installer#relative_path(bundle) abort
   let cmd = 'cd '.vundle#installer#shellesc(g:bundle_dir).' && git rev-parse --show-prefix'
   let cmd = vundle#installer#shellesc_cd(cmd)
   let prefix = s:strip(s:system(cmd))
-  return prefix.substitute(bundle.path(), g:bundle_dir.'/', '', '')
+  return prefix.substitute(a:bundle.path(), g:bundle_dir.'/', '', '')
 endf
 
 " ---------------------------------------------------------------------------
@@ -288,7 +288,7 @@ func! vundle#installer#delete(bang, dir_name) abort
 
   if vundle#installer#should_use_submodules()
     let top_level_path = vundle#installer#top_level_path()
-    let relative_path  = vundle#installer#relative_path()
+    let relative_path  = vundle#installer#relative_path(bundle)
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(top_level_path),
                 \ 'git config -f .gitmodules --remove-section submodule.'.vundle#installer#shellesc(relative_path),
@@ -442,7 +442,7 @@ func! s:make_sync_command(bang, bundle) abort
   else
     if vundle#installer#should_use_submodules()
       let top_level_path = vundle#installer#top_level_path()
-      let relative_path  = vundle#installer#relative_path()
+      let relative_path  = vundle#installer#relative_path(a:bundle)
       let cmd_parts = [
                   \ 'cd '.vundle#installer#shellesc(top_level_path),
                   \ 'git submodule add '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(relative_path),


### PR DESCRIPTION
When the user's ".vim" folder is part of a git repo, using git clone and git add (as the plugin does) creates a "semi-submodule" which doesn't work properly. This commit makes vundle check first if this is the case, and if so properly adds the bundles as git submodules.
