### PR TITLE
Updated readme to use "tpope/vim-rails.git" repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@
      Bundle 'tpope/vim-fugitive'
      Bundle 'Lokaltog/vim-easymotion'
      Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
+     Bundle 'tpope/vim-rails.git'
      " vim-scripts repos
      Bundle 'L9'
      Bundle 'FuzzyFinder'
-     Bundle 'rails.vim'
      " non github repos
      Bundle 'git://git.wincent.com/command-t.git'
      " ...


### PR DESCRIPTION
Just started using Vundle, great idea for vim plugin management.

I found bundling `rails.vim` from vim-scripts threw an autoload error when I tried loading a Rails project. Switching the bundle to github `tpope/vim-rails.git` worked fine, so am proposing a minor change to the readme.

Thanks,
Chris

_Note: using vim 7.2 on Elementary OS (Ubuntu 10.10)_
