### PR TITLE
Disable autocommands in the vundle view

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -42,7 +42,7 @@ func! vundle#scripts#view(title, headers, results)
     exec g:vundle_view.'bd!'
   endif
 
-  exec 'silent pedit [Vundle] '.a:title
+  exec 'noautocmd silent pedit [Vundle] '.a:title
 
   wincmd P | wincmd H
 


### PR DESCRIPTION
This will in particular omit the BufNewFile event with an inappropriate
wildcard pattern.
