### PR TITLE
Added .gitignore file so as to play nicely as a git submodule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When using vundle as a submodule in my .vim git repo, git status always complains about the untracked files in .vim/bundle/vundle, which turn out to be in doc/tags. Adding the generated help tags to .gitignore should prevent this. 
