### PR TITLE
Make 'clean' and 'has_doc' functions compatible with Vim 7.1+

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -126,7 +126,7 @@ endf
 
 func! vundle#installer#clean(bang) abort
   let bundle_dirs = map(copy(g:bundles), 'v:val.path()') 
-  let all_dirs = split(globpath(g:bundle_dir, '*', 1), "\n")
+  let all_dirs = v:version >= 702 ? split(globpath(g:bundle_dir, '*', 1), "\n") : split(globpath(g:bundle_dir, '*'), "\n")
   let x_dirs = filter(all_dirs, '0 > index(bundle_dirs, v:val)')
 
   if empty(x_dirs)
@@ -179,7 +179,9 @@ endf
 func! s:has_doc(rtp) abort
   return isdirectory(a:rtp.'/doc')
   \   && (!filereadable(a:rtp.'/doc/tags') || filewritable(a:rtp.'/doc/tags'))
-  \   && !(empty(glob(a:rtp.'/doc/*.txt', 1)) && empty(glob(a:rtp.'/doc/*.??x', 1)))
+  \   && v:version >= 702
+  \     ? !(empty(glob(a:rtp.'/doc/*.txt', 1)) && empty(glob(a:rtp.'/doc/*.??x', 1)))
+  \     : !(empty(glob(a:rtp.'/doc/*.txt')) && empty(glob(a:rtp.'/doc/*.??x')))
 endf
 
 func! s:helptags(rtp) abort


### PR DESCRIPTION
This pull request is simply a compatibility update for Vim 7.1.

The following commit: https://github.com/gmarik/vundle/commit/43080a1e5cf789d311b30a9b7c7497e70758da71 , introduces an incompatibility with Vim 7.1 (and under, I assume), since the glob() and globpath() functions only take 2 arguments in this version (no flag).

My solution is to just check the version and use the appropriate call so that Vundle doesn't throw errors when checking for docs or cleaning managed plugins.
