### PR TITLE
Loading bundles after VimEnter

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -7,6 +7,9 @@
 com! -nargs=+         Bundle
 \ call vundle#config#bundle(<args>)
 
+com! -nargs=+         BundleLoad
+\ call vundle#installer#load(<args>)
+
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall
 \ call vundle#installer#new('!' == '<bang>', <q-args>)
 

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -7,7 +7,7 @@
 com! -nargs=+         Bundle
 \ call vundle#config#bundle(<args>)
 
-com! -nargs=+         BundleLoad
+com! -nargs=+ -complete=custom,vundle#scripts#unloaded BundleLoad
 \ call vundle#installer#load(<args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall
@@ -22,8 +22,8 @@ com! -nargs=? -bang -complete=custom,vundle#scripts#complete Bundles
 com! -nargs=0 -bang BundleList
 \ call vundle#installer#list('!'=='<bang>')
 
-com! -nargs=? -bang   BundleClean
-\ call vundle#installer#clean('!' == '<bang>')
+com! -nargs=? -bang -complete=custom,vundle#scripts#unloaded BundleClean
+\ call vundle#installer#clean('!' == '<bang>', <args>)
 
 com! -nargs=0         BundleDocs 
 \ call vundle#installer#helptags(g:bundles)

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -11,6 +11,16 @@ func! vundle#installer#new(bang, ...) abort
   call vundle#config#require(bundles)
 endf
 
+func! vundle#installer#load(...)
+    echom join(a:000,'')
+  let bundles = (a:0 == '') ?
+        \ g:bundles :
+        \ map(copy(a:000), 'vundle#config#bundle(v:val, {})')
+  call vundle#config#require(bundles)
+  " apply newly loaded ftbundles to currently open buffers
+  echom join(bundles,'')
+  doautoall BufRead
+endf
 
 func! s:process(bang, cmd)
   let msg = ''

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -22,6 +22,10 @@ func! vundle#scripts#complete(a,c,d)
   return join(s:load_scripts(0),"\n")
 endf
 
+func! vundle#scripts#unloaded(a,c,d)
+   return join(map(vundle#installer#unloaded(), ' printf("'."'%s'".'", v:val) '),"\n")
+endf
+
 func! s:view_log()
   if !exists('g:vundle_log_file')
     let g:vundle_log_file = tempname()


### PR DESCRIPTION
I have come up with a method to load bundles after startup, using the `BundleLoad` command.  `BundleLoad` loads the plugin into the rtp, basically running along the lines of `vundle#installer#install`, but hidden.  It then runs a `doautoall BufRead` to refresh all of the open buffers.

I am using this along with an `au FileType` command and a custom dictionary to automatically load packages based on the filetype I am currently using to give the same kind of effect from the unbundle package by @sunaku.  

I have also included adjustments to the `BundleClean` package including command line autocomplete of unmanaged plugins, allowing one to run `BundleClean` on an individual package.

An example of my FTBundle capability is as follows:

    autocmd FileType * :call <sid>FTBundles(expand('<amatch>'))

     fun! s:FTBundles(ftype)
        " echom a:ftype
        let ftype = a:ftype

        let activate = []
        for [k,v] in items(g:vundle_plugins)
            if (type(ftype) == type('') && ftype == k)
                call extend(activate, v)
                if match(g:vundle_loaded,k[0]) == -1
                    let g:vundle_loaded .= k[0]
                else
                    return
                endif
            endif
        endfor
        if !empty(activate)
            exec 'BundleLoad "'. join(activate,'","').'"'
        endif
    endf

and my plugin dictionary looks like this:

    let g:vundle_plugins = {
            \ 'python': ['klen/python-mode'],
            \ 'code': ['rson/vim-conque',  'bkad/CamelCaseMotion', 'ciaranm/detectindent', 'tpope/vim-endwise'],
            \ 'blog': ['Vimblr', 'bit:pentie/vimrepress'],
            \ 'org': [ 'jceb/vim-orgmode',  'tpope/vim-speeddating',  'hsitz/VimOrganizer'],
            \ 'ruby': [  'tpope/vim-ruby'],
            \ 'tex': [ 'LaTeX-Box', 'git://vim-latex.git.sourceforge.net/gitroot/vim-latex/vim-latex'],
            \ 'autohotkey': [ 'autohotkey-ahk'],
            \ 'markdown': [  'tpope/vim-markdown'],
            \ 'javascript': [ 'pangloss/vim-javascript'],
            \ 'docs': [ 'vim-pandoc/vim-pandoc', 'robgleeson/hammer.vim', 'mikewest/vimroom']
            \ }