### PR TITLE
Add bootstrap code to .vimrc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
      set nocompatible               " be iMproved
      filetype off                   " required!
 
+     if !isdirectory(expand("~/.vim/bundle/vundle"))
+       !mkdir -p ~/.vim/bundle
+       !git clone git://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+       let s:bootstrap=1
+     endif
+
      set rtp+=~/.vim/bundle/vundle/
      call vundle#rc()
 
@@ -40,6 +46,11 @@
      " non github repos
      Bundle 'git://git.wincent.com/command-t.git'
      " ...
+
+     if exists("s:bootstrap") && s:bootstrap
+       unlet s:bootstrap
+       BundleInstall
+     endif
 
      filetype plugin indent on     " required! 
      "


### PR DESCRIPTION
This pull request addresses another form of the [Chicken Or Egg Dilemma](http://www.gmarik.info/blog/2011/05/17/chicken-or-egg-dilemma): ensuring a smooth experience with a newly checkout/clone for a version controlled home directory.  This change has the following main features:
- It creates the initial clone of Vundle, as needed.
- Only if this is the "bootstrapping" run, then run BundleInstall before the rest of `.vimrc` runs.

As a straw-man, I've gone ahead and put the sample bootstrapping code right into `README.md`.  Other alternatives include putting an updated `bundles.vim` template right into the repo (with a pointer from README and/or FAQ) or just punt it into the Vundle wiki.

Especially as someone migrating from a pathogen-with-submodules setup, this was something of a stumbling block: I wanted a significantly better out-of-box experience with Vundle on a new box vs. Pathogen.  So far, this seems to work great.
