### PR TITLE
Use --git-dir= instead of cd'ing.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -198,11 +198,12 @@ func! s:sync(bang, bundle) abort
   let git_dir = expand(a:bundle.path().'/.git/', 1)
   if isdirectory(git_dir)
     if !(a:bang) | return 'todate' | endif
-    let cmd = 'cd '.shellescape(a:bundle.path()).' && git pull'
+    let cmd = 'git --git-dir='.shellescape(git_dir).' pull'
 
     if (has('win32') || has('win64'))
-      let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
-      let cmd = '"'.cmd.'"'                          " enclose in quotes
+      " For Windows, enclose in quotes.
+      " http://groups.google.com/group/vim_use/browse_thread/thread/bab99ec9253c59ed
+      let cmd = '"'.cmd.'"'
     endif
   else
     let cmd = 'git clone '.a:bundle.uri.' '.shellescape(a:bundle.path())


### PR DESCRIPTION
This is a cleaner way to specify the git directory.  It _should_ work in Windows, and let us avoid using `/d`.  I don't have access to a Windows machine, though, so this needs testing.
