### PR TITLE
Don't rely on `git` command output.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -212,7 +212,7 @@ func! s:sync(bang, bundle) abort
     if (has('win32') || has('win64'))
       let change_cmd = substitute(change_cmd, '^cd ','cd /d ','')  " add /d switch to change drives
       let change_cmd = '"'.change_cmd.'"'                          " enclose in quotes
-  endif
+    endif
 
     let cmd = change_cmd.' && git rev-parse HEAD'
     let initial_sha = s:system(cmd)


### PR DESCRIPTION
This commit introduces `rev-parse HEAD` in order to parse the commits at
which HEAD points before and after `git pull`. If the commits are the
same, the bundle is considered 'up-to-date'. If the commits are different,
then the HEAD was fast-forwarded and the bundle is considered 'updated'.

This approach is more reliable than parsing the output of the `git` command
as it can differ between OSes and locales.

Tested on Ubuntu 11.10. The control characters at the end of the output of
`git rev-parse` are stripped away using '[:cntrl:]', assuming cross-platform.
