### PR TITLE
Changelog does not work on Windows

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -39,9 +39,17 @@ func! s:create_changelog() abort
     let updated_sha = bundle_data[1]
     let bundle      = bundle_data[2]
 
-    let updates = system('cd '.shellescape(bundle.path()).
+    let cmd = 'cd '.shellescape(bundle.path()).
           \              ' && git log --pretty=format:"%s   %an, %ar" --graph '.
-          \               initial_sha.'..'.updated_sha)
+          \               initial_sha.'..'.updated_sha
+
+    if (has('win32') || has('win64'))
+      let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
+      let cmd = '"'.cmd.'"'                          " enclose in quotes
+    endif
+
+    let updates = system(cmd)
+
     call add(g:vundle_changelog, '')
     call add(g:vundle_changelog, 'Updated Bundle: '.bundle.name)
 


### PR DESCRIPTION
I updated my vundle installation to contain the new changelog feature.
After running BundleInstall! there were a lot of updates so I pressed 'u'.
This is an extract from the result:

> Updated Bundles:
> 
> Updated Bundle: vim-rails
> Compare at: https://github.com/tpope/vim-rails/compare/18622f4...3ff31b7
>   fatal: Not a git repository (or any of the parent directories): .git
> 
> Updated Bundle: vim-ruby
> Compare at: https://github.com/vim-ruby/vim-ruby/compare/8e4076a...6648287
>   fatal: Not a git repository (or any of the parent directories): .git 

The source for getting the log is in these lines: https://github.com/gmarik/vundle/blob/master/autoload/vundle/scripts.vim#L42-44

I remembered issue #45 and the fix in commit 63c3881a793727dcd214d4635a9d636bc1a3310b so I hacked this fix.

(As this is the second place for this functionality, maybe it is worth of getting its own function.)

With this change the changelog lists the updates:

> Updated Bundles:
> 
> Updated Bundle: vim-repeat
> Compare at: https://github.com/tpope/vim-repeat/compare/cdffdd4...2914f11
> - Support repetition with original register   Ingo Karkat, 5 months ago
> - Don't increment b:changedtick, offer invalidate instead   Ingo Karkat, 5 months ago
> - Fix adding trailing spaces when 've' is not empty   xaizek, 4 months ago

(To test this I locally reverted vim-repeat to an old commit.)
