### PR TITLE
added option parser

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -5,7 +5,7 @@
 " Version:      0.9
 
 com! -nargs=+         Bundle
-\ call vundle#config#bundle(<args>)
+\ call vundle#config#bundle(<f-args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall
 \ call vundle#installer#new('!' == '<bang>', <q-args>)


### PR DESCRIPTION
Wrote body for s:parse_options to allow users to specify config options
to the Bundle command. The most common use for this would be to set the
path to a plugins runtime files directory. If a plugin repo stores it's
runtime files in a subdirectory, you need to be able to specify the path
to this directory in order to laod the plugin. For exmaple,

" exvim stores runtime files in subdir of repo root
Bundle 'jwu/exvim' 'rtpath=./vimfiles'

The parser will read arbitary options, but currently only rtpath is
used.
