### PR TITLE
Vundle can manage Vundle, when it cloned as git submodule

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -204,7 +204,7 @@ endf
 
 func! s:sync(bang, bundle) abort
   let git_dir = expand(a:bundle.path().'/.git/', 1)
-  if isdirectory(git_dir)
+  if isdirectory(git_dir) || filereadable(expand(a:bundle.path().'/.git', 1))
     if !(a:bang) | return 'todate' | endif
     let cmd = 'cd '.shellescape(a:bundle.path()).' && git pull'
 


### PR DESCRIPTION
When vundle installed as git submodule, git create file '.git' instead of
directory '.git' .

When I do :BundleInstall 'autoload/vundle/installer.vim'  think there is no '.git' directory in my 'bundle/vundle'
and try to clone vundle repo. It cause 'directory exists error'

Now we check for '.git' file exists and we think if this file readable, this is git repo.
