### PR TITLE
Fix wget/win32 codepath for script searching.

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -163,7 +163,7 @@ func! s:fetch_scripts(to)
     let temp = shellescape(tempname())
     let cmd = 'wget -q -O '.temp.' '.l:vim_scripts_json. ' && mv -f '.temp.' '.shellescape(a:to)
     if (has('win32') || has('win64')) 
-      let cmd = substitute(cmd, 'mv -f ', 'mv /Y ') " change force flag
+      let cmd = substitute(cmd, 'mv -f ', 'move /Y ', '') " change force flag
       let cmd = '"'.cmd.'"'                         " enclose in quotes so && joined cmds work
     end
   else


### PR DESCRIPTION
The codepath does not appear to have been tested; mv on Win32 is move,
and substitute has 4 arguments instead of 3.

Vundle works without curl but with wget in path on win32 after this change.
