### PR TITLE
Fix tests which allow compatibility with older versions of glob* functions

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -134,7 +134,9 @@ endf
 
 func! vundle#installer#clean(bang) abort
   let bundle_dirs = map(copy(g:bundles), 'v:val.path()') 
-  let all_dirs = v:version >= 702 ? split(globpath(g:bundle_dir, '*', 1), "\n") : split(globpath(g:bundle_dir, '*'), "\n")
+  let all_dirs = (v:version > 702 || (v:version == 702 && has("patch51")))
+  \   ? split(globpath(g:bundle_dir, '*', 1), "\n")
+  \   : split(globpath(g:bundle_dir, '*'), "\n")
   let x_dirs = filter(all_dirs, '0 > index(bundle_dirs, v:val)')
 
   if empty(x_dirs)
@@ -187,7 +189,7 @@ endf
 func! s:has_doc(rtp) abort
   return isdirectory(a:rtp.'/doc')
   \   && (!filereadable(a:rtp.'/doc/tags') || filewritable(a:rtp.'/doc/tags'))
-  \   && v:version >= 702
+  \   && (v:version > 702 || (v:version == 702 && has("patch51")))
   \     ? !(empty(glob(a:rtp.'/doc/*.txt', 1)) && empty(glob(a:rtp.'/doc/*.??x', 1)))
   \     : !(empty(glob(a:rtp.'/doc/*.txt')) && empty(glob(a:rtp.'/doc/*.??x')))
 endf


### PR DESCRIPTION
In the [previous pull request](https://github.com/gmarik/vundle/pull/129) I made to resolve this issue, I incorrectly assumed that all versions of vim 7.2 contained the updated versions of glob{,path}(), but as discovered by chenkaie [here](https://github.com/gmarik/vundle/pull/129#commitcomment-1663806), this is not the case.

It appears that only versions of vim 7.2 that contain patch number 51 [0] have the updated functions so I've updated the tests accordingly.

[0] http://vimdoc.sourceforge.net/htmldoc/version7.html#fixed-7.3 - search for 7.2.051
