### PR TITLE
Add support to install script into a specific directory.

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -101,6 +101,11 @@ endf
 let s:bundle = {}
 
 func! s:bundle.path()
-  return s:expand_path(g:bundle_dir.'/'.self.name)
+  if exists('self.dir')
+      let dir = self.dir
+  else
+      let dir = self.name
+  endif
+  return s:expand_path(g:bundle_dir.'/'.dir)
 endf
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -100,7 +100,8 @@ endf
 func! vundle#installer#install(bang, name) abort
   if !isdirectory(g:bundle_dir) | call mkdir(g:bundle_dir, 'p') | endif
 
-  let b = vundle#config#init_bundle(a:name, {})
+  let n = substitute(a:name,"['".'"]\+','','g')
+  let b = filter(copy(g:bundles), 'v:val.name_spec == n')[0]
 
   return s:sync(a:bang, b)
 endf

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -64,8 +64,8 @@ in order to install/search [all available vim scripts]
      " My Bundles here:
      "
      " original repos on github
-     Bundle 'tpope/vim-fugitive'
-     Bundle 'Lokaltog/vim-easymotion'
+     Bundle 'tpope/vim-fugitive', {'dir': 'plugin-fugitive'}
+     Bundle 'Lokaltog/vim-easymotion', {'dir': 'plugin-easymotion'}
      Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
      " vim-scripts repos
      Bundle 'L9'
@@ -98,6 +98,12 @@ command in `.vimrc`: >
     Bundle 'git_repo_uri'       " 'git_repo_uri' should be a valid uri to git repository 
 or >
     Bundle 'script_name'        " 'script-name' should be an official script name (see |vundle-scripts-search| )
+
+If you want install script into a specific directory under bundle, a dictionary
+contains the desired directory name with key 'dir' could be appended to the
+`Bundle` command.
+
+    Bundle 'git_repo_uri', {'dir':'install_dir'}  " the script will be installed at 'bundle/install_dir'
 
 Vundle loves Github, that's why short uris can be used with commands: >
 


### PR DESCRIPTION
Sometimes we may want to specify the directory name which the script will be installed to, Eg, distinguish plugins, colors and syntax with different prefix. 

Here is my current `Bundle` configurations with this patch.

```
" let Vundle manage Vundle
" required!
Bundle 'gmarik/vundle', {'dir': 'vundle'}

Bundle 'majutsushi/tagbar', {'dir': 'plugin-tagbar'}
Bundle 'techlivezheng/tagbar-phpctags', {'dir': 'plugin-tagbar-phpctags'}
Bundle 'scrooloose/nerdtree', {'dir': 'plugin-nerdtree'}
Bundle 'wincent/Command-T', {'dir': 'plugin-command-t'}
Bundle 'msanders/snipmate.vim', {'dir': 'plugin-snipmate'}
Bundle 'fholgado/minibufexpl.vim', {'dir': 'plugin-minibufexpl'}
Bundle 'tpope/vim-surround', {'dir': 'plugin-surround'}
Bundle 'tpope/vim-repeat', {'dir': 'plugin-repeat'}
Bundle 'altercation/vim-colors-solarized', {'dir': 'colors-solarized'}
Bundle 'bufkill.vim', {'dir': 'plugin-bufkill'}
Bundle 'tomtom/checksyntax_vim', {'dir': 'plugin-checksyntax'}
Bundle 'tomtom/quickfixsigns_vim', {'dir': 'plugin-quickfixsigns'}
Bundle 'Lokaltog/vim-powerline', {'dir': 'plugin-powerline'}
Bundle 'plasticboy/vim-markdown', {'dir': 'syntax-markdown'}
```
