### PR TITLE
Closes #206

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -25,6 +25,8 @@ com! -nargs=? -bang   BundleClean
 com! -nargs=0         BundleDocs 
 \ call vundle#installer#helptags(g:bundles)
 
+" Aliases
+com! BundleUpdate BundleInstall!
 
 if (has('signs'))
 sign define Vu_error    text=!  texthl=Error


### PR DESCRIPTION
'BundleUpdate' is a more intuitive and explicit command, whereas 'BundleInstall!' isn't.
