### PR TITLE
Vim patch446 compatibility

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -212,7 +212,9 @@ func! s:sync(bang, bundle) abort
 
     if (has('win32') || has('win64'))
       let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
-      let cmd = '"'.cmd.'"'                          " enclose in quotes
+      if (version < 703 || (version == 703 && !has('patch445')))
+        let cmd = '"'.cmd.'"'                          " enclose in quotes
+      endif
     endif
 
     let get_current_sha = 'cd '.shellescape(a:bundle.path()).' && git rev-parse HEAD'


### PR DESCRIPTION
This should fix #146 -- inconsistency between windows cmd quoting for vim <7.3.443 and >7.3.445 (I'm ignoring the patches inbetween for simplicity) -- without asking the user to set shellxquote= (which could break other scripts), and assuming that the user has default settings. The manual adding of quotes is a hack for bad shell quoting in <7.3.443, so this basically makes that quoting conditional on whether that patch exists. Since there were a couple of patches fixing shell quotes, fairly arbitrarily picked 445, assuming that people would either have vanilla 7.3 or >7.3.445
