### PR TITLE
really support ssh default proto

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -59,7 +59,11 @@ func! s:parse_name(arg)
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
   else
     let name = arg
-    let uri  = git_proto.'://github.com/vim-scripts/'.name.'.git'
+    if git_proto ==? 'ssh'
+      let uri = 'git@github.com:vim-scripts/'.name.'.git'
+    else
+      let uri = git_proto.'://github.com/vim-scripts/'.name.'.git'
+    endif
   endif
   return {'name': name, 'uri': uri, 'name_spec': arg }
 endf


### PR DESCRIPTION
The current version of vundle doesn't generate correct uri when g:vundle_default_git_proto is set to 'ssh' and the name contains only repo name. This is a simple fix for this.
