### PR TITLE
 Link ftdetect files into ~/.vim/ftdetect (fix: #176, #210)

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -172,11 +172,6 @@ func! vundle#installer#delete(bang, dir_name) abort
     let unlink_target = expand("$HOME/.vim/ftdetect/", 1)
     let unlink_files = glob(bundle.path().'/ftdetect/*.vim', 1, 1)
 
-    call s:log('bundle path: ' . bundle.path())
-    call s:log('glob path: ' . bundle.path().'/ftdetect/*.vim')
-    call s:log('unlink target: ' . unlink_target)
-    call s:log('unlink files: ' . join(unlink_files, ', '))
-
     for file in unlink_files
       let cmd = 'rm -f '. unlink_target .fnamemodify(file, ':p:t')
       let out = s:system(cmd)


### PR DESCRIPTION
I stumbled upon a strange error where Vim does not source the ftdetect folders correctly. The internet gave some tips about "filetype off", which did not work.
So I spent the night improving my VimL knowledge and creating this rather scanty solution for the problem via symlinking each and every BUNDLE/ftdetect/*.vim to ~/.vim/ftdetect/

However, I am sure that it fixes issues #210 and #176 and might also fix #136.

What I am not 100% sure of, is that this is the optimal way to go (and it's not for windows), but I do see something that could be improved upon.
Feel free to close the request for any reason, but I'd very much appreciate feedback as this is my first time contributing to a project. :)
