### PR TITLE
Let users set the location of git

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -38,6 +38,7 @@ endif
 
 
 func! vundle#rc(...) abort
+  let g:vundle_git_exec = 'git'
   let g:bundle_dir = len(a:000) > 0 ? expand(a:1, 1) : expand('$HOME/.vim/bundle', 1)
   let g:updated_bundles = []
   let g:vundle_log = []

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -104,3 +104,6 @@ func! s:bundle.path()
   return s:expand_path(g:bundle_dir.'/'.self.name)
 endf
 
+func! s:vundle_git_exec()
+  return shellescape(g:vundle_git_exec)
+endf

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -205,20 +205,21 @@ func! s:helptags(rtp) abort
 endf
 
 func! s:sync(bang, bundle) abort
+  let git = s:vundle_git_exec()
   let git_dir = expand(a:bundle.path().'/.git/', 1)
   if isdirectory(git_dir) || filereadable(expand(a:bundle.path().'/.git', 1))
     if !(a:bang) | return 'todate' | endif
-    let cmd = 'cd '.shellescape(a:bundle.path()).' && git pull && git submodule update --init --recursive'
+    let cmd = 'cd '.shellescape(a:bundle.path()).' && ' . git . ' pull && ' . git . ' submodule update --init --recursive'
 
     if (has('win32') || has('win64'))
       let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
       let cmd = '"'.cmd.'"'                          " enclose in quotes
     endif
 
-    let get_current_sha = 'cd '.shellescape(a:bundle.path()).' && git rev-parse HEAD'
+    let get_current_sha = 'cd '.shellescape(a:bundle.path()).' && ' . git . ' rev-parse HEAD'
     let initial_sha = s:system(get_current_sha)[0:15]
   else
-    let cmd = 'git clone --recursive '.a:bundle.uri.' '.shellescape(a:bundle.path())
+    let cmd = git . ' clone --recursive '.a:bundle.uri.' '.shellescape(a:bundle.path())
     let initial_sha = ''
   endif
 

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -40,7 +40,7 @@ func! s:create_changelog() abort
     let bundle      = bundle_data[2]
 
     let cmd = 'cd '.shellescape(bundle.path()).
-          \              ' && git log --pretty=format:"%s   %an, %ar" --graph '.
+          \              ' && ' . git . ' log --pretty=format:"%s   %an, %ar" --graph '.
           \               initial_sha.'..'.updated_sha
 
     if (has('win32') || has('win64'))


### PR DESCRIPTION
With MacVim, I've had a lot of problems getting executables called from my PATH. Setting the location of git explicitly makes life much easier.
