### PR TITLE
Use the global bundles instead of reinitializing

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -100,7 +100,8 @@ endf
 func! vundle#installer#install(bang, name) abort
   if !isdirectory(g:bundle_dir) | call mkdir(g:bundle_dir, 'p') | endif
 
-  let b = vundle#config#init_bundle(a:name, {})
+  let n = substitute(a:name,"['".'"]\+','','g')
+  let b = filter(copy(g:bundles), 'v:val.name_spec == n')[0]
 
   return s:sync(a:bang, b)
 endf


### PR DESCRIPTION
This PR makes it possible to let additional information of a Bundle to be used like in commit techlivezheng/vim-plugin-vundle@f88bdbf. It is part of a PR #200 I previously submitted and been rejected due to duplication.

This is a resubmition of PR #230 which I accidently closed.
