### PR TITLE
escaping shell commands on windows

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -210,12 +210,10 @@ func! s:sync(bang, bundle) abort
     if !(a:bang) | return 'todate' | endif
     let cmd = 'cd '.shellescape(a:bundle.path()).' && git pull && git submodule update --init --recursive'
 
-    if (has('win32') || has('win64'))
-      let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
-      let cmd = '"'.cmd.'"'                          " enclose in quotes
-    endif
+    let cmd = g:shellesc_cd(cmd)
 
     let get_current_sha = 'cd '.shellescape(a:bundle.path()).' && git rev-parse HEAD'
+    let get_current_sha = g:shellesc_cd(get_current_sha)
     let initial_sha = s:system(get_current_sha)[0:15]
   else
     let cmd = 'git clone --recursive '.a:bundle.uri.' '.shellescape(a:bundle.path())
@@ -244,6 +242,25 @@ func! s:sync(bang, bundle) abort
 
   call add(g:updated_bundles, [initial_sha, updated_sha, a:bundle])
   return 'updated'
+endf
+
+func! g:shellesc(cmd) abort
+  if (has('win32') || has('win64'))
+    if &shellxquote != '('                           " workaround for patch #445
+      return '"'.a:cmd.'"'                          " enclose in quotes so && joined cmds work
+    endif
+  endif
+  return a:cmd
+endf
+
+func! g:shellesc_cd(cmd) abort
+  if (has('win32') || has('win64'))
+    let cmd = substitute(a:cmd, '^cd ','cd /d ','')  " add /d switch to change drives
+    let cmd = g:shellesc(cmd)
+    return cmd
+  else
+    return a:cmd
+  endif
 endf
 
 func! s:system(cmd) abort

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -43,10 +43,7 @@ func! s:create_changelog() abort
           \              ' && git log --pretty=format:"%s   %an, %ar" --graph '.
           \               initial_sha.'..'.updated_sha
 
-    if (has('win32') || has('win64'))
-      let cmd = substitute(cmd, '^cd ','cd /d ','')  " add /d switch to change drives
-      let cmd = '"'.cmd.'"'                          " enclose in quotes
-    endif
+    let cmd = g:shellesc_cd(cmd)
 
     let updates = system(cmd)
 
@@ -164,7 +161,7 @@ func! s:fetch_scripts(to)
     let cmd = 'wget -q -O '.temp.' '.l:vim_scripts_json. ' && mv -f '.temp.' '.shellescape(a:to)
     if (has('win32') || has('win64')) 
       let cmd = substitute(cmd, 'mv -f ', 'move /Y ', '') " change force flag
-      let cmd = '"'.cmd.'"'                         " enclose in quotes so && joined cmds work
+      let cmd = g:shellesc(cmd)
     end
   else
     echoerr 'Error curl or wget is not available!'


### PR DESCRIPTION
inspired by
https://github.com/gmarik/vundle/pull/228 and
https://github.com/gmarik/vundle/pull/172

Vim patch #445 changed shell escaping and introduced incompatabilities for vundle.
Now vundle only escapes joined commands with double quotes on windows when shellxquote is not set to '('.
This workaround closes https://github.com/gmarik/vundle/issues/146 - the mentioned workaround
is no longer needed, but it does not break a vim configurations which contains "set shellxquote=".

DRY shell escaping and modified (hopefully) all relevant places.

Tested with :BundleInstall and :BundleInstall! on Windows 7 64bit with vim 7.3.709.
