### PR TITLE
Ignore netrwhist file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+.netrwhist


### PR DESCRIPTION
First of all, thanks for this wonderful vim plugin!

This file gets generated I think when I run vundle install. I notice many people at my work also have this problem and I think this file could be safely ignored?

Thank you!
