### PR TITLE
Fix wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ see [`:h vundle`](vundle/blob/master/doc/vundle.txt#L1) vimdoc for more details.
 
 ## People Using Vundle
 
-see [Examples](/gmarik/vundle/wiki/Examples)
+see [Examples](https://github.com/gmarik/vundle/wiki/Examples)
 
 ## FAQ
 
-see [wiki](/gmarik/vundle/wiki)
+see [wiki](https://github.com/gmarik/vundle/wiki)
 
 ## Contributors
 


### PR DESCRIPTION
This seems to have broken with [GitHub's relative link change](https://github.com/blog/1395-relative-links-in-markup-files)
