### PR TITLE
add .netrwhist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+.netrwhist


### PR DESCRIPTION
.netrwhist gets added a number of ways, and annoyingly makes the repo dirty if you're using vundle as a git submodule
