### PR TITLE
bundler link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ see [wiki](https://github.com/gmarik/vundle/wiki)
 
 [Vundle]:http://github.com/gmarik/vundle
 [Pathogen]:http://github.com/tpope/vim-pathogen/
-[Bundler]:http://github.com/wycats/bundler/
+[Bundler]:https://github.com/carlhuda/bundler
 [Vim]:http://www.vim.org
 [Git]:http://git-scm.com
 [all available vim scripts]:http://vim-scripts.org/vim/scripts.html


### PR DESCRIPTION
I think you should use the correct "bundler" link .It is updated now. if you intentionally targeted https://github.com/wycats/bundler/ then please ignore/deny this pull request . 
