### PR TITLE
Removed preceding whitespace in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,60 +8,60 @@
 
 1. Setup [Vundle]:
 
-     ```
-     $ git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
-     ```
+    ```
+    $ git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+    ```
 
 2. Configure bundles:
 
-     Sample `.vimrc`:
+    Sample `.vimrc`:
 
-     ```vim
-     set nocompatible               " be iMproved
-     filetype off                   " required!
+    ```vim
+    set nocompatible            " be iMproved
+    filetype off                " required!
 
-     set rtp+=~/.vim/bundle/vundle/
-     call vundle#rc()
+    set rtp+=~/.vim/bundle/vundle/
+    call vundle#rc()
 
-     " let Vundle manage Vundle
-     " required! 
-     Bundle 'gmarik/vundle'
+    " let Vundle manage Vundle
+    " required! 
+    Bundle 'gmarik/vundle'
 
-     " My Bundles here:
-     "
-     " original repos on github
-     Bundle 'tpope/vim-fugitive'
-     Bundle 'Lokaltog/vim-easymotion'
-     Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
-     Bundle 'tpope/vim-rails.git'
-     " vim-scripts repos
-     Bundle 'L9'
-     Bundle 'FuzzyFinder'
-     " non github repos
-     Bundle 'git://git.wincent.com/command-t.git'
-     " ...
+    " My Bundles here:
+    "
+    " original repos on github
+    Bundle 'tpope/vim-fugitive'
+    Bundle 'Lokaltog/vim-easymotion'
+    Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
+    Bundle 'tpope/vim-rails.git'
+    " vim-scripts repos
+    Bundle 'L9'
+    Bundle 'FuzzyFinder'
+    " non github repos
+    Bundle 'git://git.wincent.com/command-t.git'
+    " ...
 
-     filetype plugin indent on     " required!
-     "
-     " Brief help
-     " :BundleList          - list configured bundles
-     " :BundleInstall(!)    - install(update) bundles
-     " :BundleSearch(!) foo - search(or refresh cache first) for foo
-     " :BundleClean(!)      - confirm(or auto-approve) removal of unused bundles
-     "
-     " see :h vundle for more details or wiki for FAQ
-     " NOTE: comments after Bundle command are not allowed..
+    filetype plugin indent on    " required!
+    "
+    " Brief help
+    " :BundleList        - list configured bundles
+    " :BundleInstall(!)    - install(update) bundles
+    " :BundleSearch(!) foo - search(or refresh cache first) for foo
+    " :BundleClean(!)     - confirm(or auto-approve) removal of unused bundles
+    "
+    " see :h vundle for more details or wiki for FAQ
+    " NOTE: comments after Bundle command are not allowed..
 
-     ```
+    ```
 
 3. Install configured bundles:
 
-     Launch `vim`, run `:BundleInstall` 
-     (or `vim +BundleInstall +qall` for CLI lovers)
+    Launch `vim`, run `:BundleInstall` 
+    (or `vim +BundleInstall +qall` for CLI lovers)
 
-     *Windows users* see [Vundle for Windows](https://github.com/gmarik/vundle/wiki/Vundle-for-Windows)
+    *Windows users* see [Vundle for Windows](https://github.com/gmarik/vundle/wiki/Vundle-for-Windows)
 
-     Installing requires [Git] and triggers [Git clone](http://gitref.org/creating/#clone) for each configured repo to `~/.vim/bundle/`.
+    Installing requires [Git] and triggers [Git clone](http://gitref.org/creating/#clone) for each configured repo to `~/.vim/bundle/`.
 
 4. Consider [donating](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=T44EJZX8RBUWY)
 


### PR DESCRIPTION
Removed the preceding whitespace to make terminal commands and the example .vimrc more copy/paste friendly.

For example:

```
 `set nocompatible               " be iMproved
```

is changed to:

```
`set nocompatible               " be iMproved
```
