### PR TITLE
Re-add support for paths starting with '~' 

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -55,7 +55,8 @@ func! s:parse_name(arg)
   elseif arg =~? '^\s*\(git@\|git://\)\S\+' 
   \   || arg =~? '\(file\|https\?\)://'
   \   || arg =~? '\.git\s*$'
-    let uri = arg
+  \   || arg =~? '\V~'
+    let uri = substitute(arg, '\V~', expand('~'), '')
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
   else
     let name = arg


### PR DESCRIPTION
This seems to have worked it the past, and I think it's a great feature – you avoid having to write the full path to a repo.
