### PR TITLE
Added support for cygwin shells on Windows

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -260,7 +260,7 @@ func! g:shellesc(cmd) abort
 endf
 
 func! g:shellesc_cd(cmd) abort
-  if (has('win32') || has('win64'))
+  if ((has('win32') || has('win64')) && match(&shellcmdflag, "/") != -1)
     let cmd = substitute(a:cmd, '^cd ','cd /d ','')  " add /d switch to change drives
     let cmd = g:shellesc(cmd)
     return cmd


### PR DESCRIPTION
Vundle breaks under windows when using linux shells (possible with [VimShell](http://code.google.com/p/vimshell/). This change fixes it. It’s hard to detect what kind of shell we are using, but checking if `shellcmdflag` contains a `/` should detect all true windows shells.
