### PR TITLE
Readme and doc clarification about local git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
      Bundle 'FuzzyFinder'
      " non github repos
      Bundle 'git://git.wincent.com/command-t.git'
+     " git repos on your local machine (ie. when working on your own plugin)
+     Bundle 'file:///Users/gmarik/path/to/plugin'
      " ...
 
      filetype plugin indent on     " required!

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -73,6 +73,8 @@ in order to install/search [all available vim scripts]
      Bundle 'rails.vim'
      " non github repos
      Bundle 'git://git.wincent.com/command-t.git'
+     " git repos on your local machine (ie. when working on your own plugin)
+     Bundle 'file:///Users/gmarik/path/to/plugin'
      " ...
 
      filetype plugin indent on     " required!


### PR DESCRIPTION
First of all, thank you for the great plugin!

This pull request contains short update to doc and `README.md` on how to use local git repo as a plugin.
Recently I was working on a plugin of my own. I didn't know how to test local updates I made to the plugin in separate repo. The work around was to push updates to remote repo (master branch), and then load that repo with Bundle. That felt like too much work.

Making updates directly to `~/.vim/bundles/plugin/` is too messy.

The solution to this is pretty simple - you just specify a path to local git repo like this (note the path is absolute):
`Bundle 'file:///Users/gmarik/path/to/plugin'`

It took me more than one hour of exploring the vundle documentation, source code and googling to "find the solution". I figured an update to documentation would save that time to other people that want to do the same thing.

Hope this is helpful!
