### PR TITLE
check for single win

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -79,6 +79,13 @@ func! vundle#scripts#bundle_names(names)
 endf
 
 func! vundle#scripts#view(title, headers, results)
+  "testing whether we have 
+  "single empty window 
+  let l:vundle_single_win=0
+  if winnr()==1 && line('$') == 1 && getline(1) == '' 
+    let l:vundle_single_win=1
+  endif
+
   if exists('g:vundle_view') && bufloaded(g:vundle_view)
     exec g:vundle_view.'bd!'
   endif
@@ -86,6 +93,9 @@ func! vundle#scripts#view(title, headers, results)
   exec 'silent pedit [Vundle] '.a:title
 
   wincmd P | wincmd H
+  if l:vundle_single_win==1
+    on!
+  endif
 
   let g:vundle_view = bufnr('%')
   "


### PR DESCRIPTION
When you run vundle in vim with only one window opened, even if it is empty vundle still creates split:
![split](https://f.cloud.github.com/assets/1726487/905417/ecbf3b54-fc24-11e2-833b-1711101d6bad.png)

I made small check for that. Now if you have one empty window vundle creates single window, if you had anything opened it acts the same as before. 
