### PR TITLE
vim runtime directory path, working on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@
      (or `vim +BundleInstall +qall` for CLI lovers)
 
      *Windows users* see [Vundle for Windows](https://github.com/gmarik/vundle/wiki/Vundle-for-Windows)
+     and set vim runtime directory in your _vimrc using
+     
+         set rtp+=$HOME/vimfiles/bundle/vundle/
 
      Installing requires [Git] and triggers [Git clone](http://gitref.org/creating/#clone) for each configured repo to `~/.vim/bundle/`.
 


### PR DESCRIPTION
I couldn't use Vundle on Windows until I cheanged the rtp path setting.

Please tell me if you prefer I push on another branch, or whatever I should do to add this small modification I thought is worth to share
