### PR TITLE
use Shallow Clones instead of complete Clones to speed up :BundleInstall

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -222,7 +222,7 @@ func! s:sync(bang, bundle) abort
     let get_current_sha = g:shellesc_cd(get_current_sha)
     let initial_sha = s:system(get_current_sha)[0:15]
   else
-    let cmd = 'git clone --recursive '.shellescape(a:bundle.uri).' '.shellescape(a:bundle.path())
+    let cmd = 'git clone --dept=1 --recursive '.shellescape(a:bundle.uri).' '.shellescape(a:bundle.path())
     let initial_sha = ''
   endif
 


### PR DESCRIPTION
I think most people would prefer to only download the latest version of vim plugins:

http://mortalpowers.com/news/speed-up-git-clone-with-shallow-clones
