### PR TITLE
Added a condition to check for  when assigning cmd to execute.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -169,7 +169,7 @@ endf
 
 func! vundle#installer#delete(bang, dir_name) abort
 
-  let cmd = (has('win32') || has('win64')) ?
+  let cmd = ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh'))) ?
   \           'rmdir /S /Q' :
   \           'rm -rf'
 
@@ -251,7 +251,7 @@ func! s:sync(bang, bundle) abort
 endf
 
 func! g:shellesc(cmd) abort
-  if (has('win32') || has('win64'))
+  if ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh')))
     if &shellxquote != '('                           " workaround for patch #445
       return '"'.a:cmd.'"'                          " enclose in quotes so && joined cmds work
     endif
@@ -260,7 +260,7 @@ func! g:shellesc(cmd) abort
 endf
 
 func! g:shellesc_cd(cmd) abort
-  if (has('win32') || has('win64'))
+  if ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh')))
     let cmd = substitute(a:cmd, '^cd ','cd /d ','')  " add /d switch to change drives
     let cmd = g:shellesc(cmd)
     return cmd


### PR DESCRIPTION
Currently vundle does not consult the `shell` variable in vim to make changes of its commands. Vundle broke when I used gvim with cygwin's bash as my shell. 

```
    set shell=C:/cygwin/bin/bash
```

For example, it would try to use `rmdir` with `/Q` flag when I tried to do BundleClean. The proposed version checks to see if `shell` contains any string match for "sh". This would avoid using Windows only commands for most Unix based shells (e.g. fish, bash, zsh, csh...)
