### PR TITLE
Update README.md to clarify setting for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
    set nocompatible              " be iMproved
    filetype off                  " required!
    
-   set rtp+=~/.vim/bundle/vundle/
+   set rtp+=~/.vim/bundle/vundle/ "Use ~/vimfiles/bundle/vundle if you're following instruction for Windows
    call vundle#rc()
    
    " let Vundle manage Vundle


### PR DESCRIPTION
Added a comment to clarify the path if someone followed the windows setup instruction. (rtp should be ~/vimfiles/bundle/vundle instead of the original one, since that's what the Windows instruction told users to do)
