### PR TITLE
added spell to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
+spell/
 .netrwhist


### PR DESCRIPTION
If user doesn't already have a spell folder in their .vim, the default action is to create it in the RTP, which is what vundle makes itself.
