### PR TITLE
Ensure trailing slash when sending helptags command

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -202,7 +202,7 @@ func! s:helptags(rtp) abort
   let doc_path = a:rtp.'/doc/'
   call s:log(':helptags '.doc_path)
   try
-    execute 'helptags ' . resolve(doc_path)
+    execute 'helptags ' . simplify(resolve(doc_path) . '/')
   catch
     call s:log("> Error running :helptags ".doc_path)
     return 0


### PR DESCRIPTION
I'm running vim `7.4` on Mac OS X `10.9.1`, and every time I run `BundleInstall` or `BundleUpdate`, it fails on the `helptags` step with:

```
> Error running :helptags /Users/demands/.vim/bundle/xxx/doc
```

I looked into it a bit, and it seems like this is a confluence of two bugs.
1. My version of vim is stripping the trailing slash from the input to a `resolve()` call, so `/Users/demands/.vim/bundle/xxx/doc/` becomes `/Users/demands/.vim/bundle/xxx/doc`.
2. My version of vim's `:helptags` command seems to be incapable of handling a path without a trailing slash. It spits out:
   
   ```
   E150: Not a directory: /Users/me/.vim/bundle/xxx/doc
   ```

I'm not sure if anyone else is seeing this bug, though I'd be surprised if I was the only one.

Anyway, this pull request fixes it for me. I'd like to add a test for it, but I can't figure out how to run the tests for this project. Any pointers for me? Running `vim -u test/vimrc` spit out a bunch of errors.
