### PR TITLE
Make bundle options visible to installer

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -27,7 +27,7 @@ func! vundle#config#init_bundle(name, opts)
   if a:name != substitute(a:name, '^\s*\(.\{-}\)\s*$', '\1', '')
     echo "Spurious leading and/or trailing whitespace found in bundle spec '" . a:name . "'"
   endif
-  let opts = extend(s:parse_options(a:opts), s:parse_name(substitute(a:name,"['".'"]\+','','g')))
+  let opts = extend(s:parse_options(a:opts), s:parse_name(substitute(a:name,"['".'"]\+','','g')), 'keep')
   let b = extend(opts, copy(s:bundle))
   let b.rtpath = s:rtpath(opts)
   return b

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -128,16 +128,39 @@ follow on the same line as the command. Example:
 >
   Bundle 'git_URI'
 
-There can also be a second argument after URI.  It has to be a dictionary with
-a key called 'rtp'.  The value for that key is a directory inside the
-repository (relative path from the root of the repository) where the vim
-plugin resides.  For example:
+The `Bundle` command can optionally take a second argument after the URI. It
+has to be a dictionary, separated from the URI by a comma. Each key-value pair
+in the dictionary is a configuration option.
+
+The following per-script configuration options are available.
+
+The 'rtp' option
+----------------
+
+Specifies a directory inside the repository (relative path from the root of
+the repository) where the vim plugin resides. It determines the path that will
+be added to the |runtimepath|.
+
+For example:
 >
   Bundle 'git_URI', {'rtp': 'some/subdir/'}
 
 This can be used with git repositories that put the vim plugin inside a
 subdirectory.
 
+The 'name' option
+-----------------
+
+The name of the directory that will hold the local clone of the configured
+script.
+
+For example:
+>
+  Bundle 'git_URI', {'name': 'newPluginName'}
+
+This can be used to prevent name collisions between plugins that Vundle would
+otherwise try to clone into the same directory. It also provides an additional
+level of customisation.
 
 3.2 SUPPORTED URIS ~
                                                                 *vundle-uris*

--- a/test/vimrc
+++ b/test/vimrc
@@ -50,6 +50,7 @@ Bundle '~/Dropbox/.gitrepos/utilz.vim.git'
 
 " with options
 Bundle 'rstacruz/sparkup.git', {'rtp': 'vim/'}
+Bundle 'matchit.zip', {'name': 'matchit'}
 
 " Camel case
 Bundle 'vim-scripts/RubySinatra'


### PR DESCRIPTION
Bundle configuration options that are inferred from the bundle specs 
overwrite user provided ones. This used to prevent users from changing the
name of directory where the cloned bundle should go, for instance.

Keep the user provided options with a preference over inferred ones.
