### PR TITLE
Add a command to visit the homepage of a Bundle

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -23,6 +23,9 @@ com! -nargs=? -bang   PluginClean
 com! -nargs=0         PluginDocs
 \ call vundle#installer#helptags(g:vundle#bundles)
 
+com! -nargs=1         PluginVisitHome
+\ call vundle#scripts#visit_bundle_home(<q-args>)
+
 " Aliases
 com! -nargs=* -complete=custom,vundle#scripts#complete PluginUpdate PluginInstall! <args>
 

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -213,6 +213,51 @@ endf
 
 
 " ---------------------------------------------------------------------------
+" Open the homepage of the given plugin in a browser.  If the plugin is a
+" local one :Explore it.
+"
+" arg: A plugin specification like for :Plugin
+" ---------------------------------------------------------------------------
+func! vundle#scripts#visit_bundle_home(arg)
+  let uri = vundle#config#init_bundle(a:arg)['uri']
+  if exists(':OpenBrowser')
+    " See https://github.com/tyru/open-browser.vim
+    execute 'OpenBrowser' uri
+  else
+    " The user does not have the open-browser plugin installed so we have to
+    " try to open the uri ourself.
+    let protocoll = split(uri, ':')[0]
+    if protocoll == 'file'
+      execute 'Vexplore' uri[7:]
+      return
+    elseif protocoll =~ 'https?'
+      " FIXME is there a better way to test for OS X?  This is false with the
+      " stock version of vim.
+      if has('macunix')
+        execute '!open' uri
+        return
+      elseif has('win16') || has('win32') || has('win64')
+        execute '!start' uri
+        " FIXME should this be:
+        "execute 'cmd /c start' uri
+        return
+      elseif has('unix')
+        if executable('xgd-open')
+          execute '!xgd-open' uri
+          " FIXME are there other ways to open uris on linux (besides calling
+          " firefox or chrome directly)?  What do Gnome, KDE or XFCE provide?
+          return
+        endif
+      endif
+    endif
+    " if we reach this point we either can not open the uri (it is a git:// uri)
+    " or we do not know how to open stuff on this system.
+    echomsg 'The uri for this plugin is' uri.'.  Please open it yourself.'
+  endif
+endf
+
+
+" ---------------------------------------------------------------------------
 " Load the plugin database from vim-scripts.org .
 "
 " to     -- the filename (string) to save the database to


### PR DESCRIPTION
The command BundleVisitHomepage can will try to take the user to the homepage
or directory the bundle is cloned from.

This is not yet system independent and can not yet handle full git uris.

**questions and ideas:**
This is still work in progress. Do you think it is a feature that should be included into vundle?

 It might be interesting for people who demanded some information on the plugins inside the search window where some key could be mapped to this function.

If you have ideas how to handle general git uris or open uris on different systems please comment. (What can you do on windows to open an uri? On linux we might try for `xdg-open` or are there many window managers and desktop environments that don't support it?)
