### PR TITLE
Support pinned (a.k.a. static) bundles

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -78,6 +78,7 @@ sign define Vu_new      text=+  texthl=Comment
 sign define Vu_updated  text=*  texthl=Comment
 sign define Vu_deleted  text=-  texthl=Comment
 sign define Vu_helptags text=*  texthl=Comment
+sign define Vu_pinned   text==  texthl=Comment
 endif
 
 

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -107,3 +107,7 @@ func! s:bundle.path()
   return s:expand_path(g:bundle_dir.'/'.self.name)
 endf
 
+func! s:bundle.is_pinned()
+  return get(self, 'pinned')
+endf
+

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -67,6 +67,8 @@ func! vundle#installer#run(func_name, name, ...) abort
     echo n.' deleted'
   elseif 'helptags' == status
     echo n.' regenerated'
+  elseif 'pinned' == status
+    echo n.' pinned'
   elseif 'error' == status
     echohl Error
     echo 'Error processing '.n
@@ -219,6 +221,11 @@ func! s:helptags(rtp) abort
 endf
 
 func! s:sync(bang, bundle) abort
+  " Do not sync if this bundle is pinned
+  if a:bundle.is_pinned()
+    return 'pinned'
+  endif
+
   let git_dir = expand(a:bundle.path().'/.git/', 1)
   if isdirectory(git_dir) || filereadable(expand(a:bundle.path().'/.git', 1))
     if !(a:bang) | return 'todate' | endif

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -166,6 +166,26 @@ This can be used to prevent name collisions between plugins that Vundle would
 otherwise try to clone into the same directory. It also provides an additional
 level of customisation.
 
+The 'pinned' option
+-------------------
+
+A flag that, when set to a value of 1, tells Vundle not to perform any git
+operations on the plugin, while still adding the existing plugin under the
+`bundles` directories to the |runtimepath|.
+
+For example:
+>
+  Plugin 'mylocalplugin', {'pinned': 1}
+
+This allows the users to include, with Vundle, plugins tracked with version
+control systems other than git, but the user is responsible for cloning and
+keeping up to date. It also allows the users to stay in the current version of
+a plugin that might have previously been updated by Vundle.
+
+Please note that the URI will be treated the same as for any other plugins, so
+only the last part of it will be added to the |runtimepath|. The user is
+advised to use this flag only with single word URIs to avoid confusion.
+
 3.2 SUPPORTED URIS ~
                                                         *vundle-plugins-uris*
 
@@ -185,7 +205,7 @@ GitHub is used when a user/repo is passed to `Plugin`.
 
 Vim Scripts
 -----------
-Any single word without a '/' is assumed to be from Vim Scripts.
+Any single word without a slash '/' is assumed to be from Vim Scripts.
 >
   Plugin 'ctrlp.vim' => https://github.com/vim-scripts/ctrlp.vim
 

--- a/test/vimrc
+++ b/test/vimrc
@@ -58,6 +58,13 @@ Bundle 'vim-scripts/RubySinatra'
 " syntax issue #203
 Bundle 'jimenezrick/vimerl'
 
+" Static bundle: Same name as a valid vim-scripts bundle
+Bundle 'latte', {'pinned' : 1}
+if !isdirectory(expand(bundle_dir) . '/latte')
+  call mkdir(expand(bundle_dir) . '/latte', 'p')
+endif
+
+
 filetype plugin indent on      " Automatically detect file types.
 
 set wildignore+=doc            " should not break helptags


### PR DESCRIPTION
I have revived this old piece of code that was sitting on my fork, which only makes sense to integrate now that the installer remembers the configuration.

New supported option called `static` for the Bundle command. When set to 1, the bundle is added to rtp but no install/upgrade operation is performed.

Fixes #24, #397

@gmarik @starcraftman Thoughts?
