### PR TITLE
update deprecated API to call the new API directly

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -12,13 +12,13 @@ com! -nargs=? -bang -complete=custom,vundle#scripts#complete PluginInstall
 \ call vundle#installer#new('!' == '<bang>', <q-args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete PluginSearch
-\ call vundle#scripts#all('!'=='<bang>', <q-args>)
+\ call vundle#scripts#all('!' == '<bang>', <q-args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete Plugins
-\ call vundle#scripts#all('!'=='<bang>', <q-args>)
+\ call vundle#scripts#all('!' == '<bang>', <q-args>)
 
 com! -nargs=0 -bang PluginList
-\ call vundle#installer#list('!'=='<bang>')
+\ call vundle#installer#list('!' == '<bang>')
 
 com! -nargs=? -bang   PluginClean
 \ call vundle#installer#clean('!' == '<bang>')
@@ -30,45 +30,21 @@ com! -nargs=0         PluginDocs
 com! PluginUpdate PluginInstall!
 
 " Vundle Aliases
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleInstall
-\ call vundle#installer#new('!' == '<bang>', <q-args>)
-
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleSearch
-\ call vundle#scripts#all('!'=='<bang>', <q-args>)
-
-com! -nargs=? -bang   VundleClean
-\ call vundle#installer#clean('!' == '<bang>')
-
-com! -nargs=0         VundleDocs
-\ call vundle#installer#helptags(g:bundles)
-
-" Aliases
-com! VundleUpdate PluginInstall!
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleInstall PluginList<bang> <args>
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleSearch  PluginSearch<bang> <args>
+com! -nargs=? -bang                                          VundleClean   PluginClean<bang>
+com! -nargs=0                                                VundleDocs    PluginDocs
+com!                                                         VundleUpdate  PluginInstall!
 
 " deprecated
-com! -nargs=+         Bundle
-\ call vundle#config#bundle(<args>)
-
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall
-\ call vundle#installer#new('!' == '<bang>', <q-args>)
-
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleSearch
-\ call vundle#scripts#all('!'=='<bang>', <q-args>)
-
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete Bundles
-\ call vundle#scripts#all('!'=='<bang>', <q-args>)
-
-com! -nargs=0 -bang BundleList
-\ call vundle#installer#list('!'=='<bang>')
-
-com! -nargs=? -bang   BundleClean
-\ call vundle#installer#clean('!' == '<bang>')
-
-com! -nargs=0         BundleDocs
-\ call vundle#installer#helptags(g:bundles)
-
-" Aliases
-com! BundleUpdate BundleInstall!
+com! -nargs=+                                                Bundle        call vundle#config#bundle(<args>)
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleInstall PluginInstall<bang> <args>
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete BundleSearch  PluginSearch<bang> <args>
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete Bundles       Plugins<bang> <args>
+com! -nargs=0 -bang                                          BundleList    PluginList<bang>
+com! -nargs=? -bang                                          BundleClean   PluginClean<bang>
+com! -nargs=0                                                BundleDocs    PluginDocs
+com!                                                         BundleUpdate  PluginInstall!
 
 if (has('signs'))
 sign define Vu_error    text=!  texthl=Error
@@ -85,6 +61,6 @@ func! vundle#rc(...) abort
   let g:bundle_dir = len(a:000) > 0 ? expand(a:1, 1) : expand('$HOME/.vim/bundle', 1)
   let g:updated_bundles = []
   let g:vundle_log = []
-  let g:vundle_changelog = ['Updated Bundles:']
+  let g:vundle_changelog = ['Updated Plugins:']
   call vundle#config#init()
 endf

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -138,10 +138,10 @@ func! vundle#scripts#view(title, headers, results)
   nnoremap <buffer> h :h vundle<CR>
   nnoremap <buffer> ? :norm h<CR>
 
-  nnoremap <buffer> c :BundleClean<CR>
-  nnoremap <buffer> C :BundleClean!<CR>
+  nnoremap <buffer> c :PluginClean<CR>
+  nnoremap <buffer> C :PluginClean!<CR>
 
-  nnoremap <buffer> s :BundleSearch
+  nnoremap <buffer> s :PluginSearch
   nnoremap <buffer> R :call vundle#scripts#reload()<CR>
 
   " goto first line after headers


### PR DESCRIPTION
The idea here is to call the new API directly in order to reduce the amount of code and to reduce the amount of maintenance (changes to the new API will automatically be "backported")

Disadvantage: Might break compatibility for the old API?
