### PR TITLE
Add 'Unplug' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@
    " The sparkup vim script is in a subdirectory of this repo called vim.
    " Pass the path to set the runtimepath properly.
    Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
+   Plugin 'tpope/vim-fugitive'
+   " Invalid a Plugin
+   Unplug 'tpope/vim-fugitive'
    " scripts from http://vim-scripts.org/vim/scripts.html
    Plugin 'L9'
    Plugin 'FuzzyFinder'

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -8,6 +8,9 @@
 com! -nargs=+  -bar   Plugin
 \ call vundle#config#bundle(<args>)
 
+com! -nargs=+  -bar   Unplug
+\ call vundle#config#unplug(<args>)
+
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete PluginInstall
 \ call vundle#installer#new('!' == '<bang>', <q-args>)
 
@@ -30,7 +33,7 @@ com! -nargs=0         PluginDocs
 com! PluginUpdate PluginInstall!
 
 " Vundle Aliases
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleInstall PluginList<bang> <args>
+com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleInstall PluginInstall<bang> <args>
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleSearch  PluginSearch<bang> <args>
 com! -nargs=? -bang                                          VundleClean   PluginClean<bang>
 com! -nargs=0                                                VundleDocs    PluginDocs

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -6,6 +6,19 @@ func! vundle#config#bundle(arg, ...)
   return bundle
 endf
 
+func! vundle#config#unplug(arg, ...)
+  let bundle = vundle#config#init_bundle(a:arg, a:000)
+  let bundle_index=0
+  for b in g:bundles
+    if bundle.name_spec == b.name_spec
+      call s:rtp_rm(b.rtpath)
+      unlet g:bundles[bundle_index]
+      break
+    endif
+    let bundle_index=bundle_index+1
+  endfor
+endf
+
 func! vundle#config#init()
   if !exists('g:bundles') | let g:bundles = [] | endif
   call s:rtp_rm_a()

--- a/test/vimrc
+++ b/test/vimrc
@@ -52,6 +52,8 @@ Bundle '~/Dropbox/.gitrepos/utilz.vim.git'
 Bundle 'rstacruz/sparkup.git', {'rtp': 'vim/'}
 Bundle 'matchit.zip', {'name': 'matchit'}
 
+UnPlug 'molokai' "make molokai invalid
+
 " Camel case
 Bundle 'vim-scripts/RubySinatra'
 


### PR DESCRIPTION
I add the command in order to invalid the previous plugin.

For this scenario, I have a vimrc call `vimrc.bundles` which is not allowed to changing:

``` VimL
Plugin 'foo'
Plugin 'bar'
```

In my .vimrc, I have to source the `vimrc.bundles` whereas the 'bar' isn't suit for my env, so I can use `Unplug`:

> ~/.vimrc:

``` VimL
source vimrc.bundles

" Invalid 'foo'
Unplug 'foo'
" Use Vundle as well
Pulgin 'Align'
" ...
```

It may be suitable for https://github.com/gmarik/Vundle.vim/pull/422#issuecomment-39438671
