### PR TITLE
Documentation Update.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Issues
 
 Before submitting an issue, be sure to check the following places for answers.
 
-1. Vundle docs at [`:h vundle`](https://github.com/gmarik/vundle/blob/master/doc/vundle.txt).
+1. Vundle docs at [`:h vundle`](https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt).
 
 2. The [FAQ](https://github.com/gmarik/Vundle.vim/search).
 
@@ -53,9 +53,9 @@ Vimrc:
 set nocompatible
 syntax on
 filetype off
-set rtp+=~/.vim/bundle/vundle/
+set rtp+=~/.vim/bundle/Vundle.vim/
 call vundle#rc()
-Bundle 'gmarik/vundle'
+Bundle 'gmarik/Vundle.vim'
 Bundle 'relevant/plugin'
 filetype plugin indent on
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## [Help Maintain Vundle](https://github.com/gmarik/Vundle.vim/issues/241)
+## [Help Maintain Vundle](https://github.com/gmarik/Vundle.vim/issues/383)
 
 ## About
 
@@ -30,10 +30,11 @@
    Curl is required for search.
 
    If you are using Windows, go directly to [Windows setup]. If you run into any issues, please consult the [FAQ].
+   See [Tips] for some advanced configurations.
 
 2. Set up [Vundle]:
 
-   `$ git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle`
+   `$ git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim`
 
 3. Configure Plugins:
 
@@ -44,34 +45,33 @@
    filetype off                  " required
 
    " set the runtime path to include Vundle and initialize
-   set rtp+=~/.vim/bundle/vundle/
-   call vundle#rc()
+   set rtp+=~/.vim/bundle/Vundle.vim
+   call vundle#begin()
    " alternatively, pass a path where Vundle should install plugins
-   "let path = '~/some/path/here'
-   "call vundle#rc(path)
+   "call vundle#begin('~/some/path/here')
 
    " let Vundle manage Vundle, required
-   Plugin 'gmarik/vundle'
+   Plugin 'gmarik/Vundle.vim'
 
    " The following are examples of different formats supported.
-   " Keep Plugin commands between here and filetype plugin indent on.
-   " scripts on GitHub repos
+   " Keep Plugin commands between vundle#begin/end.
+   " plugin on GitHub repo
    Plugin 'tpope/vim-fugitive'
-   Plugin 'Lokaltog/vim-easymotion'
-   Plugin 'tpope/vim-rails.git'
-   " The sparkup vim script is in a subdirectory of this repo called vim.
-   " Pass the path to set the runtimepath properly.
-   Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
-   " scripts from http://vim-scripts.org/vim/scripts.html
+   " plugin from http://vim-scripts.org/vim/scripts.html
    Plugin 'L9'
-   Plugin 'FuzzyFinder'
-   " scripts not on GitHub
+   " plugin not on GitHub
    Plugin 'git://git.wincent.com/command-t.git'
    " git repos on your local machine (i.e. when working on your own plugin)
    Plugin 'file:///home/gmarik/path/to/plugin'
-   " ...
+   " The sparkup vim script is in a subdirectory of this repo called vim.
+   " Pass the path to set the runtimepath properly.
+   Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
+   " Avoid a name conflict with L9
+   Plugin 'user/L9', {'name': 'newL9'}
 
-   filetype plugin indent on     " required
+   " All of your Plugins must be added before the following line
+   call vundle#end()            " required
+   filetype plugin indent on    " required
    " To ignore plugin indent changes, instead use:
    "filetype plugin on
    "
@@ -82,27 +82,26 @@
    " :PluginClean(!)      - confirm (or auto-approve) removal of unused plugins
    "
    " see :h vundle for more details or wiki for FAQ
-   " NOTE: comments after Plugin commands are not allowed.
-   " Put your stuff after this line
+   " Put your non-Plugin stuff after this line
    ```
 
 4. Install Plugins:
 
-   Launch `vim` and  run `:PluginInstall`
+   Launch `vim` and run `:PluginInstall`
 
    To install from command line: `vim +PluginInstall +qall`
 
 ## Docs
 
-See the [`:h vundle`](https://github.com/gmarik/vundle/blob/master/doc/vundle.txt) Vimdoc for more details.
+See the [`:h vundle`](https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt) Vimdoc for more details.
 
 ## People Using Vundle
 
-see [Examples](https://github.com/gmarik/vundle/wiki/Examples)
+see [Examples](https://github.com/gmarik/Vundle.vim/wiki/Examples)
 
 ## Contributors
 
-see [Vundle contributors](https://github.com/gmarik/vundle/graphs/contributors)
+see [Vundle contributors](https://github.com/gmarik/Vundle.vim/graphs/contributors)
 
 *Thank you!*
 
@@ -132,9 +131,10 @@ see [Vundle contributors](https://github.com/gmarik/vundle/graphs/contributors)
 * search by description as well
 * make it rock!
 
-[Vundle]:http://github.com/gmarik/vundle
-[Windows setup]:https://github.com/gmarik/vundle/wiki/Vundle-for-Windows
-[FAQ]:https://github.com/gmarik/vundle/wiki
+[Vundle]:http://github.com/gmarik/Vundle.vim
+[Windows setup]:https://github.com/gmarik/Vundle.vim/wiki/Vundle-for-Windows
+[FAQ]:https://github.com/gmarik/Vundle.vim/wiki
+[Tips]:https://github.com/gmarik/Vundle.vim/wiki/Tips-and-Tricks
 [Vim]:http://www.vim.org
 [Git]:http://git-scm.com
 [`git clone`]:http://gitref.org/creating/#clone
@@ -143,10 +143,10 @@ see [Vundle contributors](https://github.com/gmarik/vundle/graphs/contributors)
 [help tags]:http://vimdoc.sourceforge.net/htmldoc/helphelp.html#:helptags
 [runtime path]:http://vimdoc.sourceforge.net/htmldoc/options.html#%27runtimepath%27
 
-[configure]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L122-L205
-[install]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L207-L226
-[update]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L228-L237
-[search]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L239-L267
-[clean]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L276-L289
-[interactive mode]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L292-L331
-[interface change]:https://github.com/gmarik/vundle/blob/master/doc/vundle.txt#L345-L369
+[configure]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L125-L232
+[install]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L233-L253
+[update]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L254-L264
+[search]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L265-L294
+[clean]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L302-L317
+[interactive mode]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L318-L359
+[interface change]:https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L371-L395

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -1,7 +1,7 @@
 " Vundle        is a shortcut for Vim Bundle and Is a simple plugin manager for Vim
 " Author:       gmarik
-" HomePage:     http://github.com/gmarik/vundle
-" Readme:       http://github.com/gmarik/vundle/blob/master/README.md
+" HomePage:     http://github.com/gmarik/Vundle.vim
+" Readme:       http://github.com/gmarik/Vundle.vim/blob/master/README.md
 " Version:      0.9
 
 " Plugin Commands
@@ -67,12 +67,17 @@ func! vundle#rc(...) abort
   call vundle#config#init()
 endf
 
+" Alternative to vundle#rc, offers speed up by modifying rtp only when end()
+" called later.
 func! vundle#begin(...) abort
   let g:vundle_lazy_load = 1
   call call('vundle#rc', a:000)
 endf
 
+" Finishes putting plugins on the rtp.
 func! vundle#end(...) abort
   unlet g:vundle_lazy_load
   call vundle#config#activate_bundles()
 endf
+
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -253,3 +253,4 @@ func! s:bundle.is_pinned()
   return get(self, 'pinned')
 endf
 
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -440,3 +440,5 @@ func! s:log(str, ...) abort
   endfor
   return a:str
 endf
+
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -253,3 +253,5 @@ func! s:load_scripts(bang)
   endif
   return eval(readfile(f, 'b')[0])
 endf
+
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -62,7 +62,7 @@ more information.
 
 2. Setup Vundle:
 >
-  git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+  git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
 <
 3. Configure bundles:
 
@@ -73,37 +73,44 @@ more information.
     filetype off                  " required
 
     " set the runtime path to include Vundle and initialize
-    set rtp+=~/.vim/bundle/vundle/
-    call vundle#rc()
-    " alternatively, pass a path where Vundle should install bundles
-    "let path = '~/some/path/here'
-    "call vundle#rc(path)
+    set rtp+=~/.vim/bundle/Vundle.vim
+    call vundle#begin()
+    " alternatively, pass a path where Vundle should install plugins
+    "call vundle#begin('~/some/path/here')
 
     " let Vundle manage Vundle, required
-    Plugin 'gmarik/vundle'
+    Plugin 'gmarik/Vundle.vim'
 
     " The following are examples of different formats supported.
-    " Keep bundle commands between here and filetype plugin indent on.
-    " plugins on GitHub repos
+    " Keep Plugin commands between vundle#begin/end.
+    " plugin on GitHub repo
     Plugin 'tpope/vim-fugitive'
-    Plugin 'Lokaltog/vim-easymotion'
-    Plugin 'tpope/vim-rails.git'
-    " The sparkup vim script is in a subdirectory of this repo called vim.
-    " Pass the path to set the runtimepath properly.
-    Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
-    " plugins from http://vim-scripts.org/vim/scripts.html
+    " plugin from http://vim-scripts.org/vim/scripts.html
     Plugin 'L9'
-    Plugin 'FuzzyFinder'
-    " plugins not on GitHub
+    " plugin not on GitHub
     Plugin 'git://git.wincent.com/command-t.git'
     " git repos on your local machine (i.e. when working on your own plugin)
     Plugin 'file:///home/gmarik/path/to/plugin'
-    " ...
+    " The sparkup vim script is in a subdirectory of this repo called vim.
+    " Pass the path to set the runtimepath properly.
+    Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
+    " Avoid a name conflict with L9
+    Plugin 'user/L9', {'name': 'newL9'}
 
-    filetype plugin indent on     " required
+    " All of your Plugins must be added before the following line
+    call vundle#end()            " required
+    filetype plugin indent on    " required
     " To ignore plugin indent changes, instead use:
     "filetype plugin on
-    " Put your stuff after this line
+    "
+    " Brief help
+    " :PluginList          - list configured plugins
+    " :PluginInstall(!)    - install (update) plugins
+    " :PluginSearch(!) foo - search (or refresh cache first) for foo
+    " :PluginClean(!)      - confirm (or auto-approve) removal of unused plugins
+    "
+    " see :h vundle for more details or wiki for FAQ
+    " Put your non-Plugin stuff after this line
 
 4. Install configured bundles:
 
@@ -381,11 +388,10 @@ KEY | DESCRIPTION
   BundleSearch(!)   | PluginSearch(!), VundleSearch(!)
   BundleClean       | PluginClean(!), VundleClean(!)
   BundleList        | PluginList
-  Bundles           | Plugins
 
   Note: The Bundle commands will be deprecated. You may continue using them,
   but they may not get all future updates. For instance, we have enabled
   comments on Plugin lines but not Bundle, since it requires a change in
   command declaration.
 
-vim:tw=78:ts=8:ft=help:norl:
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78 ft=help norl:

--- a/test/minirc.vim
+++ b/test/minirc.vim
@@ -1,8 +1,8 @@
 set nocompatible
 syntax on
 filetype off
-set rtp+=~/.vim/bundle/vundle/
+set rtp+=~/.vim/bundle/Vundle.vim/
 call vundle#rc()
-Bundle 'gmarik/vundle'
+Bundle 'gmarik/Vundle.vim'
 filetype plugin indent on
 

--- a/test/vimrc
+++ b/test/vimrc
@@ -4,13 +4,13 @@ set nocompatible
 set nowrap
 
 let bundle_dir = '/tmp/vundle-test/bundles/'
-" let src = 'http://github.com/gmarik/vundle.git' 
+" let src = 'http://github.com/gmarik/vundle.git'
 
 " Vundle Options
 " let g:vundle_default_git_proto = 'git'
 
 silent execute '!mkdir -p '.bundle_dir
-silent execute '!ln -f -s ~/.vim/bundle/vundle '.bundle_dir
+silent execute '!ln -f -s ~/.vim/bundle/Vundle.vim '.bundle_dir
 
 filetype off
 syntax on
@@ -18,7 +18,7 @@ syntax on
 runtime macros/matchit.vim
 
 " This test should be executed in "test" directory
-exec 'set rtp^='.bundle_dir.'vundle/'
+exec 'set rtp^='.bundle_dir.'Vundle.vim/'
 
 call vundle#rc(bundle_dir)
 
@@ -78,3 +78,4 @@ set wildignore+=*/.git/*
 au VimEnter * BundleInstall
 
 " e test/files/erlang.erl
+" vim: set expandtab sts=2 ts=2 sw=2 tw=78:


### PR DESCRIPTION
A collection of smaller changes to the documentation as well as adding modelines to all vim files so code stays correctly indented.

Changes:
- Add modelines to all code/doc files excluding README.md.  The modeline used is: `" vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:` So code patches stay consistent. @jdevera noted this might help on a previous commit.
- Rename links with /vundle to /Vundle.vim, seems to confuse some people with redirect.
- Remove duplicates from Quickstart, add example of `name` flag.
- Changed quickstart to demonstrate begin/end.
- Add link to Tips page by @Lucc .
- Change help maintain vundle link directly to the new one.

Note: We will need to reclone/mv to Vundle.vim instead of vundle to continue using the test files. Existing users that don't need to run these can stay on vundle as long as they want.

This doc update brings the next branch up to date. After we deal with #425 & #435, we should cut a release from next -> master.  I don't think there's anything terribly objectionable in this change set but I leave it up for comment/review. Any issues @jdevera.
