### PR TITLE
Make it clearer where plugins are added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
    Plugin 'file:///home/gmarik/path/to/plugin'
    " ...
 
+   " All of your Plugins must be added before the following line
    filetype plugin indent on     " required
    " To ignore plugin indent changes, instead use:
    "filetype plugin on
@@ -83,7 +84,7 @@
    "
    " see :h vundle for more details or wiki for FAQ
    " NOTE: comments after Plugin commands are not allowed.
-   " Put your stuff after this line
+   " Put your non-Plugin stuff after this line
    ```
 
 4. Install Plugins:


### PR DESCRIPTION
When getting started with Vundle, I was confused by the comment "put your stuff after this line", thinking that "your stuff" meant your plugins. Stuff mostly worked, so it took me a while to figure out what the problem was when a plugin did not work. I hope that this comment will keep other new users from making the same mistake.
