### PR TITLE
Add cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
 .netrwhist
+cache


### PR DESCRIPTION
So those of us with vundle as a submodule of our vim directory don't have a dirty tree.
