### PR TITLE
escape spaces in s:rtp_add_defaults()

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -167,11 +167,12 @@ func! s:rtp_add_defaults()
   let default = &rtp
   let &rtp = current
   for item in reverse(split(default, ','))
-    exec 'set rtp-=' . item
+    let itemEscapeSpace = substitute(item, ' ', '\\ ', "g")
+    exec 'set rtp-=' . itemEscapeSpace
     if fnamemodify(item, ":t") == 'after'
-      exec 'set rtp+=' . item
+      exec 'set rtp+=' . itemEscapeSpace
     else
-      exec 'set rtp^=' . item
+      exec 'set rtp^=' . itemEscapeSpace
     endif
   endfor
 endf


### PR DESCRIPTION
Unescaped spaces in home directory path (i.e. ".../Macintosh HD/Users/...") cause errors like these at startup:

```
Error detected while processing function vundle#config#bundle..<SNR>4_rtp_add_defaults:
line    6:
E518: Unknown option: HD/Users/Yukun/.vim/after
line    8:
E518: Unknown option: HD/Users/Yukun/.vim/after
line    6:
E518: Unknown option: HD/Users/Yukun/.vim
line   10:
E518: Unknown option: HD/Users/Yukun/.vim
line    6:
E518: Unknown option: HD/Users/Yukun/.vim/after
line    8:
E518: Unknown option: HD/Users/Yukun/.vim/after
```
