### PR TITLE
Autoinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@
 
 2. Set up [Vundle]:
 
+   Either you install Vundle manually:
+
    `$ git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim`
+
+   or you can put these lines *before* the configureation described below:
+
+   ```vim
+   if !filereadable(expand('~/.vim/bundle/Vundle.vim/README.md'))
+     source https://raw.githubusercontent.com/gmarik/Vundle.vim/master/autoinstall.vim
+   endif
+   ```
+
+   NOTE: You might have to change the path in the test to suit you system.
 
 3. Configure Plugins:
 

--- a/autoinstall.vim
+++ b/autoinstall.vim
@@ -1,0 +1,43 @@
+" This installation script is intended to be loaded from the internet and
+" sourced from your vimrc file like this:
+"
+"   if !fileradable(expand('~/.vim/bundle/Vundle.vim/README.md'))
+"     source https://raw.githubusercontent.com/gmarik/Vundle.vim/master/autoinstall.vim
+"   endif
+"
+" This will load the script from github and source it.  If you put the above
+" lines in your vimrc file before setting up Vundle.vim you will get an
+" automated installation process for every new machine you use your vimrc on.
+
+echomsg 'Starting automatic installation of Vundle.vim.'
+
+" the url of the Vundle.vim repository to clone
+let s:clone_uri = 'https://github.com/gmarik/Vundle.vim.git'
+
+" the path to clone Vundle.vim to
+if has('unix') " we seem to be on a UNIX compatible system
+  let s:path = expand('~/.vim/bundle/Vundle.vim')
+elseif has('win32') " we are on some variant of Windows
+  let s:path = expand('~/vimfiles/bundle/Vundle.vim')
+else
+  echoerr 'Your system is not supported.  Sorry.'
+  finish
+endif
+
+" only clone if the plugin does not yet exist on disk
+if !filereadable(s:path.'/README.md')
+  call mkdir(s:path, 'p')
+  execute '!git clone' s:clone_uri s:path
+  if v:shell_error != 0
+    echoerr 'Automatic installation of Vundle.vim failed!  Please install manually.'
+    finish
+  endif
+endif
+
+" use an autocmd after startup to install all plugins for the user
+augroup VundleAutoInstall
+  autocmd!
+  autocmd VimEnter * PluginUpdate
+augroup END
+
+echomsg 'Installation of Vundle.vim complete.  Plugins will automaticaly be installed after startup.'


### PR DESCRIPTION
## previous attempts

This was mentioned some times already: #414, #144, #59
## info

This PR puts the autoinstall code in a seperated script `autoinstall.vim` which can be sourced directly from Vim. The user can thereby use a simple test to see if Vundle is installed and conditionally source the script.
## ToDo

I am not yet happy with the way I put this in the README if you have good ideas just tell me.
## problem when testing

I noticed that vim is able to source files even with help of the netrw plugin (so the file can be an url). The only problem I have at the moment is to test this script via the github link. If I source my local copy it works and installs vundle. If I try 

``` vim
:source https://raw.githubusercontent.com/lucc/vundle/autoinstall/autoinstall.vim
```

my vim uses `elinks -source` to load the script to a temp file and then gives me errors as the tempfile seems to contain html code. Both

``` sh
curl https://raw.githubusercontent.com/lucc/vundle/autoinstall/autoinstall.vim
```

and 

``` sh
elinks -source https://raw.githubusercontent.com/lucc/vundle/autoinstall/autoinstall.vim
```

work fine on the command line. Also my private test script works fine: 

``` vim
:source http://luc42.lima-city.de/test
```

(no worries it just containes `echo 'test successful'`)
