### PR TITLE
Add non-POSIX Shell fix to boilerplate vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
    set nocompatible              " be iMproved, required
    filetype off                  " required
    
-   " avoid problems for users of other shells than bash. 
+   " Avoid problems for non-POSIX shell users. 
    set shell=/bin/sh
 
    " set the runtime path to include Vundle and initialize


### PR DESCRIPTION
Due to the issue #175,

Is there a reason not to put this in the boilerplate vimrc?
