### PR TITLE
Update the url used to install plugin from github.

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -138,7 +138,7 @@ func! s:parse_name(arg)
 
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
-    let uri = git_proto.'://github.com/'.split(arg, ':')[-1]
+    let uri = git_proto.'@github.com:'.split(arg, ':')[-1]
     if uri !~? '\.git$'
       let uri .= '.git'
     endif
@@ -150,7 +150,7 @@ func! s:parse_name(arg)
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
   else
     let name = arg
-    let uri  = git_proto.'://github.com/vim-scripts/'.name.'.git'
+    let uri  = git_proto.'@github.com:vim-scripts/'.name.'.git'
   endif
   return {'name': name, 'uri': uri, 'name_spec': arg }
 endf


### PR DESCRIPTION
Currently installing plugin foo with git in vundle with have the origin url git://github.com/foo.git

For repositories that I have push access, it won't allow me to push my change.
I will have to manually change it to git@github.com:foo.git
