### PR TITLE
Don't flag name duplication when installing the same plugin twice

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -8,7 +8,7 @@
 func! vundle#config#bundle(arg, ...)
   let bundle = vundle#config#init_bundle(a:arg, a:000)
   if !s:check_bundle_name(bundle)
-    return
+    return {}
   endif
   if exists('g:vundle#lazy_load') && g:vundle#lazy_load
     call add(g:vundle#bundles, bundle)
@@ -84,24 +84,31 @@ endf
 
 
 " ---------------------------------------------------------------------------
-" Check if the current bundle name has already been used in this running
-" instance and show an error to that effect.
+" Register the name of the current bundle as aleady used or show an error if
+" it is a duplicate (determined by the URI). Duplicates with the same URI are
+" okay, since no surprises come to the user from this situation.
+"
+" Additionally, check whether the name conforms or not with the pattern of
+" expected plugin names.
 "
 " bundle -- a bundle object whose name is to be checked
-" return -- 0 if the bundle's name has been seen before, 1 otherwise
+" return -- 0 if the bundle's name has been seen before or is invalid,
+"           1 otherwise
 " ---------------------------------------------------------------------------
 funct! s:check_bundle_name(bundle)
-  if has_key(s:bundle_names, a:bundle.name)
+  if has_key(s:bundle_names, a:bundle.name) &&
+        \ s:bundle_names[a:bundle.name]['uri'] != a:bundle.uri
     echoerr 'Vundle error: Name collision for Plugin ' . a:bundle.name_spec .
-          \ '. Plugin ' . s:bundle_names[a:bundle.name] .
+          \ '. Plugin ' . s:bundle_names[a:bundle.name].spec .
           \ ' previously used the name "' . a:bundle.name . '"' .
           \ '. Skipping Plugin ' . a:bundle.name_spec . '.'
     return 0
   elseif a:bundle.name !~ '\v^[A-Za-z0-9_-]%(\.?[A-Za-z0-9_-])*$'
-    echoerr 'Invalid plugin name: ' . a:bundle.name
+    echoerr 'Vundle error: Invalid plugin name: ' . a:bundle.name
     return 0
   endif
-  let s:bundle_names[a:bundle.name] = a:bundle.name_spec
+  let s:bundle_names[a:bundle.name] = { 'spec' : a:bundle.name_spec,
+                                      \ 'uri'  : a:bundle.uri }
   return 1
 endf
 

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -98,13 +98,14 @@ endf
 funct! s:check_bundle_name(bundle)
   if has_key(s:bundle_names, a:bundle.name) &&
         \ s:bundle_names[a:bundle.name]['uri'] != a:bundle.uri
-    echoerr 'Vundle error: Name collision for Plugin ' . a:bundle.name_spec .
+    echomsg 'Vundle warning: Name collision for Plugin ' . a:bundle.name_spec .
           \ '. Plugin ' . s:bundle_names[a:bundle.name].spec .
           \ ' previously used the name "' . a:bundle.name . '"' .
           \ '. Skipping Plugin ' . a:bundle.name_spec . '.'
     return 0
   elseif a:bundle.name !~ '\v^[A-Za-z0-9_-]%(\.?[A-Za-z0-9_-])*$'
-    echoerr 'Vundle error: Invalid plugin name: ' . a:bundle.name
+    echomsg 'Vundle warning: Invalid plugin name: ' . a:bundle.name . 
+          \ '. Skipping Plugin ' . a:bundle.name_spec . '.'
     return 0
   endif
   let s:bundle_names[a:bundle.name] = { 'spec' : a:bundle.name_spec,

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -18,6 +18,8 @@ func! vundle#installer#new(bang, ...) abort
     let bundles = map(copy(a:000), 'vundle#config#bundle(v:val, {})')
   endif
 
+  let bundles = filter(copy(bundles), '!empty(v:val)')
+
   if empty(bundles)
     echoerr 'No bundles were selected for operation'
     return

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -150,11 +150,11 @@ endf
 " return -- the return value from vundle#installer#install()
 " ---------------------------------------------------------------------------
 func! vundle#installer#install_and_require(bang, name) abort
-  let result = vundle#installer#install(a:bang, a:name)
   let bundle = vundle#config#bundle(a:name, {})
   if empty(bundle)
     return 'error'
   endif
+  let result = vundle#installer#install(a:bang, a:name)
   call vundle#installer#helptags([bundle])
   call vundle#config#require([bundle])
   return result

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -21,7 +21,8 @@ func! vundle#installer#new(bang, ...) abort
   let bundles = filter(copy(bundles), '!empty(v:val)')
 
   if empty(bundles)
-    echoerr 'No bundles were selected for operation'
+    let operation = a:bang ? 'update' : 'installation'
+    echomsg 'Vundle warning: No (valid) plugins were selected for ' . operation
     return
   endif
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -149,9 +149,12 @@ endf
 " ---------------------------------------------------------------------------
 func! vundle#installer#install_and_require(bang, name) abort
   let result = vundle#installer#install(a:bang, a:name)
-  let b = vundle#config#bundle(a:name, {})
-  call vundle#installer#helptags([b])
-  call vundle#config#require([b])
+  let bundle = vundle#config#bundle(a:name, {})
+  if empty(bundle)
+    return 'error'
+  endif
+  call vundle#installer#helptags([bundle])
+  call vundle#config#require([bundle])
   return result
 endf
 

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -235,14 +235,14 @@ func! s:fetch_scripts(to)
       let cmd = vundle#installer#shellesc(cmd)
     end
   else
-    echoerr 'Error curl or wget is not available!'
+    echoerr 'Vundle error: Neither curl nor wget are available!'
     return 1
   endif
 
   call system(cmd)
 
   if (0 != v:shell_error)
-    echoerr 'Error fetching scripts!'
+    echoerr 'Vundle error: Could not fetch vim-scripts list for searching'
     return v:shell_error
   endif
   return 0


### PR DESCRIPTION
Name duplication is checked so that users don't end up overwriting one
plugin directory with the contents from another plugin that shares a
common name.

However, if the repeated plugin happens to be the same, there will be no
surprises and there is no need to flag this as an error. This needs if
particularly acute due to the fact that we currently don't show, in the
plugin search, which of the resulting plugins are already installed, so a
user might very well attempt to install a plugin they already have.

With this change, instead of seeing an error in this scenario, the user
will see a message indicating the plugin is already installed, and no
additional cloning will be performed.
