### PR TITLE
added support for specifying specific branch/tag/revision while installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@
    Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
    " Avoid a name conflict with L9
    Plugin 'user/L9', {'name': 'newL9'}
+   " Install a specific branch/tag/revision
+   Plugin 'WoLpH/nerdtree@patch-1'
 
    " All of your Plugins must be added before the following line
    call vundle#end()            " required

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -139,6 +139,13 @@ func! s:parse_name(arg)
   let arg = a:arg
   let git_proto = exists('g:vundle_default_git_proto') ? g:vundle_default_git_proto : 'https'
 
+  if arg =~? '@'
+    let revision = split(arg, '@')[-1]
+    let arg = split(arg, '@')[0]
+  else
+    let revision = 'master'
+  endif
+
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
     let uri = git_proto.'://github.com/'.split(arg, ':')[-1]
@@ -155,7 +162,7 @@ func! s:parse_name(arg)
     let name = arg
     let uri  = git_proto.'://github.com/vim-scripts/'.name.'.git'
   endif
-  return {'name': name, 'uri': uri, 'name_spec': arg }
+  return {'name': name, 'uri': uri, 'name_spec': arg, 'revision': revision }
 endf
 
 

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -393,6 +393,7 @@ func! s:make_sync_command(bang, bundle) abort
                   \ 'git fetch',
                   \ 'git reset --hard origin/HEAD',
                   \ 'git submodule update --init --recursive',
+                  \ 'git checkout '.a:bundle.revision,
                   \ ]
       let cmd = join(cmd_parts, ' && ')
       let cmd = vundle#installer#shellesc_cd(cmd)
@@ -410,14 +411,19 @@ func! s:make_sync_command(bang, bundle) abort
                 \ 'git pull',
                 \ 'git submodule update --init --recursive',
                 \ ]
-    let cmd = join(cmd_parts, ' && ')
-    let cmd = vundle#installer#shellesc_cd(cmd)
 
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd_parts = [
+                \ 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path()),
+                \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
+                \ ]
     let initial_sha = ''
   endif
+
+  let cmd_parts = cmd_parts + ['git checkout '.a:bundle.revision]
+  let cmd = join(cmd_parts, ' && ')
+  let cmd = vundle#installer#shellesc_cd(cmd)
   return [cmd, initial_sha]
 endf
 


### PR DESCRIPTION
This fixes #35 

Now it's possible to specify a tag, branch or revision using `@...`:

Example: `Plugin 'WoLpH/nerdtree@patch-1'`