### PR TITLE
use github style uri when using git protocol.

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -138,10 +138,11 @@ endf
 func! s:parse_name(arg)
   let arg = a:arg
   let git_proto = exists('g:vundle_default_git_proto') ? g:vundle_default_git_proto : 'https'
+  let github_uri_prefix = (git_proto == 'git' ? 'git@github.com:' : git_proto.'://github.com/')
 
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
-    let uri = git_proto.'://github.com/'.split(arg, ':')[-1]
+    let uri = github_uri_prefix . split(arg, ':')[-1]
     if uri !~? '\.git$'
       let uri .= '.git'
     endif
@@ -153,7 +154,7 @@ func! s:parse_name(arg)
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
   else
     let name = arg
-    let uri  = git_proto.'://github.com/vim-scripts/'.name.'.git'
+    let uri  = github_uri_prefix . '/vim-scripts/'.name.'.git'
   endif
   return {'name': name, 'uri': uri, 'name_spec': arg }
 endf

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -90,7 +90,7 @@ func! s:create_changelog() abort
     call add(changelog, '')
     call add(changelog, 'Updated Plugin: '.bundle.name)
 
-    if bundle.uri =~ "https://github.com"
+    if bundle.uri =~ "https://github.com" "TODO: what for git protocol?
       call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
     endif
 


### PR DESCRIPTION
This is a fix for #615. And I found that there is a similar pull request #232, but **this one is better**.

there is still some problem leaving:

1. if we use the `git@github.com:` style uri, user need to provide public key to clone/fetch, which is not necessary indeed. This can be solved this way: `git remote set-url --push ...` , but I'm not sure if we really need to do it like this.

2. I found that in file `autoload/vundle/scripts.vim` at line 93, the pattern `"https://github.com"` is used, and I'm not sure if we should consider different protocols here.