### PR TITLE
On Windows, Vim will sometimes have no idea where $HOME actually is. …

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -83,6 +83,8 @@ endf
 " Initialize some global variables used by Vundle.
 if has('win32') || has('win64')
   let vundle#bundle_dir = expand('$VIM/vimfiles/bundle', 1)
+elseif has('nvim')
+  let vundle#bundle_dir = expand('$HOME/.nvim/bundle', 1)
 else
   let vundle#bundle_dir = expand('$HOME/.vim/bundle', 1)
 endif

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -81,7 +81,11 @@ func! vundle#end(...) abort
 endf
 
 " Initialize some global variables used by Vundle.
-let vundle#bundle_dir = expand('$HOME/.vim/bundle', 1)
+if has('win32') || has('win64')
+  let vundle#bundle_dir = expand('$VIM/vimfiles/bundle', 1)
+else
+  let vundle#bundle_dir = expand('$HOME/.vim/bundle', 1)
+endif
 let vundle#bundles = []
 let vundle#lazy_load = 0
 let vundle#log = []


### PR DESCRIPTION
Since the default for Vim user scripts on Windows is "$VIM/vimfiles/", have Vundle direct bundles to that path instead.

On some Windows machines, $HOME is modified to direct to a shared drive or folder, and causes Vim to load to that location, as opposed to directing to the user's actual home directory. This is to avoid cloning Vim scripts to what could be shared drives for collaboration & file sharing.
