### PR TITLE
Repository references to VundleVim instead of gmarik

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,15 @@ Issues
 
 Before submitting an issue, be sure to check the following places for answers.
 
-1. Vundle docs at [`:h vundle`](https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt).
+1. Vundle docs at [`:h vundle`](https://github.com/VundleVim/Vundle.vim/blob/master/doc/vundle.txt).
 
-2. The [FAQ](https://github.com/gmarik/Vundle.vim/search).
+2. The [FAQ](https://github.com/VundleVim/Vundle.vim/wiki).
 
-3. [Search](https://github.com/gmarik/Vundle.vim/search) the repository for related issues.
+3. [Search](https://github.com/VundleVim/Vundle.vim/search) the repository for related issues.
 
 ## Try To Eliminate Your Vimrc
 
-In order to make sure it isn't just `.vimrc` replace your own config file with the [minimal vimrc](https://github.com/gmarik/Vundle.vim/blob/master/test/minirc.vim). Clear out bundles and then try to reproduce.
+In order to make sure it isn't just `.vimrc` replace your own config file with the [minimal vimrc](https://github.com/VundleVim/Vundle.vim/blob/master/test/minirc.vim). Clear out bundles and then try to reproduce.
 
 If the problem stops, likely there is an issue in your user configuration. You can incrementally add back your user changes to the minimal file testing the bug each time. This will allow you to slowly bisect the issue. You may want to test one plugin at a time.
 
@@ -46,7 +46,7 @@ To better respond to issues please follow these general guidelines when explaini
 
 I am using Vim on Kubuntu 13.04 64 bit and I get the following error... (add further explanation here)
 
-To reproduce the bug, use the vimrc file below and run `:BundleInstall`... (continue with steps)
+To reproduce the bug, use the vimrc file below and run `:PluginInstall`... (continue with steps)
 
 Vimrc:
 ```
@@ -55,8 +55,8 @@ syntax on
 filetype off
 set rtp+=~/.vim/bundle/Vundle.vim/
 call vundle#rc()
-Bundle 'gmarik/Vundle.vim'
-Bundle 'relevant/plugin'
+Plugin 'VundleVim/Vundle.vim'
+Plugin 'relevant/plugin'
 filetype plugin indent on
 
 .... more user configs here...

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -1,7 +1,7 @@
 " Vundle        is a shortcut for Vim Bundle and Is a simple plugin manager for Vim
 " Author:       gmarik
-" HomePage:     http://github.com/gmarik/Vundle.vim
-" Readme:       http://github.com/gmarik/Vundle.vim/blob/master/README.md
+" HomePage:     http://github.com/VundleVim/Vundle.vim
+" Readme:       http://github.com/VundleVim/Vundle.vim/blob/master/README.md
 " Version:      0.10.2
 
 " Plugin Commands

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -54,15 +54,15 @@ more information.
 
                                                              *vundle-windows*
   If you are using Windows, see instructions on the Wiki
-  https://github.com/gmarik/Vundle.vim/wiki/Vundle-for-Windows.
+  https://github.com/VundleVim/Vundle.vim/wiki/Vundle-for-Windows.
 
                                                                  *vundle-faq*
   If you run into any issues, please consult the FAQ at
-  https://github.com/gmarik/Vundle.vim/wiki
+  https://github.com/VundleVim/Vundle.vim/wiki
 
 2. Setup Vundle:
 >
-  git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+  git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
 <
 3. Configure bundles:
 
@@ -79,7 +79,7 @@ more information.
     "call vundle#begin('~/some/path/here')
 
     " let Vundle manage Vundle, required
-    Plugin 'gmarik/Vundle.vim'
+    Plugin 'VundleVim/Vundle.vim'
 
     " The following are examples of different formats supported.
     " Keep Plugin commands between vundle#begin/end.
@@ -208,7 +208,7 @@ GitHub
 ------
 GitHub is used when a user/repo is passed to `Plugin`.
 >
-  Plugin 'gmarik/Vundle.vim' => https://github.com/gmarik/Vundle.vim
+  Plugin 'VundleVim/Vundle.vim' => https://github.com/VundleVim/Vundle.vim
 
 Vim Scripts
 -----------

--- a/test/minirc.vim
+++ b/test/minirc.vim
@@ -3,7 +3,7 @@ syntax on
 filetype off
 set rtp+=~/.vim/bundle/Vundle.vim/
 call vundle#begin()
-Plugin 'gmarik/Vundle.vim'
+Plugin 'VundleVim/Vundle.vim'
 call vundle#end()
 filetype plugin indent on
 


### PR DESCRIPTION
Update repository references throughout documentation. Also, fixed an incorrect URL and updated references to `:Bundle` commands to `:Plugin` commands