### PR TITLE
Git plugin is now hosted on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@
    Plugin 'tpope/vim-fugitive'
    " plugin from http://vim-scripts.org/vim/scripts.html
    Plugin 'L9'
-   " Git plugin not hosted on GitHub
-   Plugin 'git://git.wincent.com/command-t.git'
+   " Git plugin is now hosted on GitHub
+   Plugin 'git@github.com:wincent/command-t.git'
    " git repos on your local machine (i.e. when working on your own plugin)
    Plugin 'file:///home/gmarik/path/to/plugin'
    " The sparkup vim script is in a subdirectory of this repo called vim.


### PR DESCRIPTION
Git plugin is now hosted on GitHub, so I updated the README.md file.