### PR TITLE
Fixes to git commands hardening.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -372,9 +372,12 @@ func! s:make_git_command(bundle, args) abort
   let workdir = a:bundle.path()
   let gitdir  = workdir.'/.git/'
 
-  let git = [g:vundle#git_executable, '--git-dir='.gitdir, '--work-tree='.workdir]
+  let git_cmd = [g:vundle#git_executable, '--git-dir', gitdir]
+  if a:args[0] != 'clone'
+    let git_cmd = git_cmd + ['-C', workdir, '--work-tree', workdir]
+  endif
 
-  return join(map(git + a:args, 'vundle#installer#shellesc(v:val)'))
+  return join(map(git_cmd + a:args, 'vundle#installer#shellesc(v:val)'))
 endf
 
 " ---------------------------------------------------------------------------

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -76,6 +76,38 @@ endf
 
 
 " ---------------------------------------------------------------------------
+" Parse the output from git log after an update to create a change log for the
+" user.
+" ---------------------------------------------------------------------------
+func! vundle#installer#create_changelog() abort
+  let changelog = ['Updated Plugins:']
+  for bundle_data in g:vundle#updated_bundles
+    let initial_sha = bundle_data[0]
+    let updated_sha = bundle_data[1]
+    let bundle      = bundle_data[2]
+
+    let cmd = s:make_git_command(bundle, ['log', '--pretty=format:%s   %an, %ar',
+                    \                     '--graph', initial_sha.'..'.updated_sha ])
+
+    let updates = system(cmd)
+
+    call add(changelog, '')
+    call add(changelog, 'Updated Plugin: '.bundle.name)
+
+    if bundle.uri =~ "https://github.com"
+      call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
+    endif
+
+    for update in split(updates, '\n')
+      let update = substitute(update, '\s\+$', '', '')
+      call add(changelog, '  '.update)
+    endfor
+  endfor
+  return changelog
+endf
+
+
+" ---------------------------------------------------------------------------
 " Call another function in the different Vundle windows.
 "
 " func_name -- the function to call

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -74,38 +74,6 @@ endf
 
 
 " ---------------------------------------------------------------------------
-" Parse the output from git log after an update to create a change log for the
-" user.
-" ---------------------------------------------------------------------------
-func! s:create_changelog() abort
-  let changelog = ['Updated Plugins:']
-  for bundle_data in g:vundle#updated_bundles
-    let initial_sha = bundle_data[0]
-    let updated_sha = bundle_data[1]
-    let bundle      = bundle_data[2]
-
-    let cmd = s:make_git_command(bundle, ['log', '--pretty=format:"%s   %an, %ar"',
-                    \                     '--graph', initial_sha.'..'.updated_sha ])
-
-    let updates = system(cmd)
-
-    call add(changelog, '')
-    call add(changelog, 'Updated Plugin: '.bundle.name)
-
-    if bundle.uri =~ "https://github.com"
-      call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
-    endif
-
-    for update in split(updates, '\n')
-      let update = substitute(update, '\s\+$', '', '')
-      call add(changelog, '  '.update)
-    endfor
-  endfor
-  return changelog
-endf
-
-
-" ---------------------------------------------------------------------------
 " View the change log after an update or installation.
 " ---------------------------------------------------------------------------
 func! s:view_changelog()
@@ -116,7 +84,7 @@ func! s:view_changelog()
   if bufloaded(s:changelog_file)
     execute 'silent bdelete' s:changelog_file
   endif
-  call writefile(s:create_changelog(), s:changelog_file)
+  call writefile(vundle#installer#create_changelog(), s:changelog_file)
   execute 'silent pedit' s:changelog_file
   set bufhidden=wipe
   setl buftype=nofile


### PR DESCRIPTION
I tested the current release, and it breaks at update time and for changelog generation.

The issue is that you need to be in the git_dir for git to work correctly for submodules, but that you cannot move to the worktree when cloning (because it does not exist yet).

The changelog was broken because make_git_command was not available in that script.
I moved one function around and exported it.

I have now tested my changes within and outside vcsh (GIT_DIR set) for the following operations:

- [X] init (clone)
- [X] update
- [ ] plugin removal
- [X] changelog
- [X] log (error reporting)

My apologizes for not having properly tested my previous patches.