### PR TITLE
use shallow clone to speed up plugin installation and save disk storage

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -415,7 +415,7 @@ func! s:make_sync_command(bang, bundle) abort
 
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd = 'git clone --depth 1 --recursive --shallow-submodules '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
     let initial_sha = ''
   endif
   return [cmd, initial_sha]


### PR DESCRIPTION
Some plugins have long time development history with huge number of commit objects. One don't need to hold the whole repo history just for using a plugin. 

For example, full clone of `YouCompleteMe` takes `32M` storage vs `1.7M` of the shallow one.

Shallow clone can speed up the installation and save disk storage. 

Please check if this affect `Vundle`'s plugin update mechanism.
