### PR TITLE
Remove example script which breaks install

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@
    " Keep Plugin commands between vundle#begin/end.
    " plugin on GitHub repo
    Plugin 'tpope/vim-fugitive'
-   " plugin from http://vim-scripts.org/vim/scripts.html
-   Plugin 'L9'
    " Git plugin not hosted on GitHub
    Plugin 'git://git.wincent.com/command-t.git'
    " git repos on your local machine (i.e. when working on your own plugin)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
    Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
    " Install L9 and avoid a Naming conflict if you've already installed a
    " different version somewhere else.
-   Plugin 'ascenator/L9', {'name': 'newL9'}
+   " Plugin 'ascenator/L9', {'name': 'newL9'}
 
    " All of your Plugins must be added before the following line
    call vundle#end()            " required

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@
    " Keep Plugin commands between vundle#begin/end.
    " plugin on GitHub repo
    Plugin 'tpope/vim-fugitive'
+   " plugin from http://vim-scripts.org/vim/scripts.html
+   " Plugin 'L9'
    " Git plugin not hosted on GitHub
    Plugin 'git://git.wincent.com/command-t.git'
    " git repos on your local machine (i.e. when working on your own plugin)


### PR DESCRIPTION
According to this discussion https://github.com/VundleVim/Vundle.vim/issues/713 this plugin is simply an example, but the example seems to consistently break the installation process.

If this is the case better to remove it.

Another example of it causing problems: https://github.com/VundleVim/Vundle.vim/issues/784