### PR TITLE
Updated choice of command for rmdir on windows OS

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -278,8 +278,8 @@ endf
 " ---------------------------------------------------------------------------
 func! vundle#installer#delete(bang, dir_name) abort
 
-  let cmd = ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh'))) ?
-  \           'rmdir /S /Q' :
+  let cmd = (has('win32') || has('win64')) ?
+  \           'cmd /C rmdir /S /Q' :
   \           'rm -rf'
 
   let bundle = vundle#config#init_bundle(a:dir_name, {})


### PR DESCRIPTION
As showed in [Issue 787](https://github.com/VundleVim/Vundle.vim/issues/787) previous choice was based on OS and the non presence of "sh" in env variable SH. This caused issue with powershell on windows (sh is in powershell) and rm was selected.

I updated the windows rm command to "cmd /C rmdir /S /Q" which will execute rmdir in a cmd.exe, removing problem of different commands between windows cmd.exe and powershell.