### PR TITLE
Add note about adding shell=/bin/bash to .vimrc for fish shell users

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@
 
    To install from command line: `vim +PluginInstall +qall`
 
+5. (optional) For those using the fish shell: add `shell=/bin/bash` to your `.vimrc`
+
 ## Docs
 
 See the [`:h vundle`](https://github.com/VundleVim/Vundle.vim/blob/master/doc/vundle.txt) Vimdoc for more details.


### PR DESCRIPTION
See #690.

My comment on the issue has 20 upvotes, so @vikeri asked if this should be in the README.

So, here I am to propose that.

Alternatives:

- Adding it `vundle#begin()` (and restoring to previous shell in `vundle#end()`
- Adding it to the fish shell instructions
- Just keeping it in an issue that people will google for