### PR TITLE
accidentally a 'set' in my vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 
    To install from command line: `vim +PluginInstall +qall`
 
-5. (optional) For those using the fish shell: add `shell=/bin/bash` to your `.vimrc`
+5. (optional) For those using the fish shell: add `set shell=/bin/bash` to your `.vimrc`
 
 ## Docs
 


### PR DESCRIPTION
`shell=/bin/bash` needs to start with `set` in order to actually make vim+fish work correctly. while vim veterans might assume the `set` is implied, it's an easy mistake to make for a vim novice to make.