### PR TITLE
Limit default rtp rearrangement

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -166,14 +166,12 @@ func! s:rtp_add_defaults()
   set rtp&vim
   let default = &rtp
   let &rtp = current
-  for item in reverse(split(default, ','))
-    exec 'set rtp-=' . item
-    if fnamemodify(item, ":t") == 'after'
-      exec 'set rtp+=' . item
-    else
-      exec 'set rtp^=' . item
-    endif
-  endfor
+  let default_rtp_items = split(default, ',')
+  if !empty(default_rtp_items)
+    let first_item = default_rtp_items[0]
+    exec 'set rtp-=' . fnameescape(first_item)
+    exec 'set rtp^=' . fnameescape(first_item)
+  endif
 endf
 
 


### PR DESCRIPTION
Rearranging rtp so that **all** default directories appear first has the
undesired side effect of not allowing plugins to override default syntax
files.

This changeset limits the rearrangement of the rtp to simply making sure
the first directory in the default runtimepath appears first in also in
the runtimepath after Vundle has finished manipulating it.

This should keep the original bugs fixed and should eliminate the
aforementioned undesired side effect.