### PR TITLE
Adds vundle-before-update tag to unbreak plugins after updates

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -407,6 +407,7 @@ func! s:make_sync_command(bang, bundle) abort
 
     let cmd_parts = [
                 \ 'cd '.vundle#installer#shellesc(a:bundle.path()),
+                \ 'git tag -f vundle-before-update',
                 \ 'git pull',
                 \ 'git submodule update --init --recursive',
                 \ ]

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -277,6 +277,16 @@ To update specific plugins, write their names separated by space:
 or >
   :PluginUpdate vim-surround vim-fugitive
 
+The command `git tag` will be used to tag the commit that was used before any 
+update (i.e. before `git pull` is run). The tag is named 
+`vundle-before-update`.  If a plugin breaks after update, go to its directory 
+and run
+
+  `git checkout vundle-before-update && \`
+  `git submodule update --init --recursive`
+
+Then mark it as 'pinned' in `.vimrc`.
+
 3.5 SEARCHING PLUGINS ~
                                       *vundle-plugins-search* *:PluginSearch*
 >


### PR DESCRIPTION
Sometimes plugins break after update. In those cases it's difficult to
restore the plugin to its previous version. With this commit Vundle will
create a tag (`vundle-before-update`) which keeps track of the commit
used before an update. This makes it easy to go back to use the previous
version.

Maybe it's better to timestamp the tags, e.g. `vundle-update-TIME`, but having one level of undo is sufficient to solve the problem.

Comments are appreciated.