### PR TITLE
Set GIT_ASKPASS environment variable before clone

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -415,7 +415,7 @@ func! s:make_sync_command(bang, bundle) abort
 
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd = 'GIT_ASKPASS="true" git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
     let initial_sha = ''
   endif
   return [cmd, initial_sha]


### PR DESCRIPTION
Right now, if you has a mistyped github repo in your vimrc and you run
:PluginInstall, then vundle hangs and asks for your github username and
password. This is caused because git wants to check to make sure the
error isn't caused by some permissions problem.

In #662 and #667, it was noted that we could fix this by setting the
GIT_ASKPASS environment variable.

In this commit, I set this environment variable for the git clone
commands.

Note: resolves #667 