### PR TITLE
Replace deprecated git clone command.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -415,7 +415,7 @@ func! s:make_sync_command(bang, bundle) abort
 
     let initial_sha = s:get_current_sha(a:bundle)
   else
-    let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let cmd = 'git clone --recurse-submodules '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
     let initial_sha = ''
   endif
   return [cmd, initial_sha]


### PR DESCRIPTION
Replaces the deprecated `--recursive` flag with `--recurse-submodules`.

The `--recursive` flag for `git clone` [has been deprecated](https://github.com/git/git/commit/bb62e0a99fcbb9ceb03502bf2168d2e57530214f) since Git v.2.13.

It should be replaced with `--recurse-submodules`, which [has been available](https://github.com/git/git/commit/ccdd3da6527ca7d8d731e691b9ff0f9b8657298e) since Git v1.7.4.

For this specific use case, the actual logic being executed would be the same.