### PR TITLE
Add 'cmd' option for plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@
    " Install L9 and avoid a Naming conflict if you've already installed a
    " different version somewhere else.
    " Plugin 'ascenator/L9', {'name': 'newL9'}
+   "
+   " Run an additional command after installation and updates. Some plugins
+   " require running build scripts to work properly.
+   Plugin 'workspace/custom', {'cmd': 'make'}
 
    " All of your Plugins must be added before the following line
    call vundle#end()            " required

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -96,6 +96,8 @@ more information.
     Plugin 'rstacruz/sparkup', {'rtp': 'vim/'}
     " Avoid a name conflict with L9
     Plugin 'user/L9', {'name': 'newL9'}
+    " Run an additional command after installation and updates
+    Plugin 'workspace/custom', {'cmd': 'make'}
 
     " All of your Plugins must be added before the following line
     call vundle#end()            " required
@@ -192,6 +194,19 @@ a plugin that might have previously been updated by Vundle.
 Please note that the URI will be treated the same as for any other plugins, so
 only the last part of it will be added to the |runtimepath|. The user is
 advised to use this flag only with single word URIs to avoid confusion.
+
+The 'cmd' option
+----------------
+
+An additional command script which runs right after installation and update
+operation process.
+
+For example:
+>
+  Plugin 'customplugin', {'cmd': './build all'}
+
+This can be usefull for complex plugins with requirements of post-install
+builds, data importing, etc. All operations must not depend on user input.
 
 3.2 SUPPORTED URIS ~
                                                         *vundle-plugins-uris*

--- a/test/vimrc
+++ b/test/vimrc
@@ -51,6 +51,7 @@ Bundle '~/Dropbox/.gitrepos/utilz.vim.git'
 " with options
 Bundle 'rstacruz/sparkup.git', {'rtp': 'vim/'}
 Bundle 'matchit.zip', {'name': 'matchit'}
+Bundle 'Valloric/YouCompleteMe', {'cmd': './install.py --clang-completer'}
 
 " Camel case
 Bundle 'vim-scripts/RubySinatra'


### PR DESCRIPTION
This PR allows to set additional post installation scripts in plugins configurations. It can be very useful for plugins such as YCM, where you need to rebuild the server on updates.

Fixes #739 