### PR TITLE
update install instruction to be on one line in smaller screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@
 
 2. Set up [Vundle]:
 
-   ` git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim`
+   ```
+   git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+   ```
 
 3. Configure Plugins:
 


### PR DESCRIPTION
could be confusion and appears at two different lines

<img width="674" alt="Screenshot 2020-07-13 at 19 09 49" src="https://user-images.githubusercontent.com/58794487/87332858-8e0abf00-c53c-11ea-8db1-87303b112488.png">
