### PR TITLE
Adapt for vim using powershell as shell in windows.

### DIFF
--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -278,7 +278,8 @@ endf
 " ---------------------------------------------------------------------------
 func! vundle#installer#delete(bang, dir_name) abort
 
-  let cmd = ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh'))) ?
+  let cmd = (&shell == 'pwsh') ? 'rm -Recurse -Force' : 
+  \         ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh'))) ?
   \           'rmdir /S /Q' :
   \           'rm -rf'
 


### PR DESCRIPTION
In order to detect the shell searchs for the string sh within the shell name (works for sh and bash and windows usual shell is cmd). This can be solved within \autoload\vundle\installer.vim
    by doing:
```vim
      let cmd = (&shell == 'pwsh') ? 'rm -Recurse -Force' : 
      \         ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh'))) ?
      \           'rmdir /S /Q' :
      \           'rm -rf'
```
note that this error happens also in:

```vim
    func! vundle#installer#shellesc(cmd) abort
      if ((has('win32') || has('win64')) && empty(matchstr(&shell, 'sh')))
        return '"' . substitute(a:cmd, '"', '\\"', 'g') . '"'
      endif
      return shellescape(a:cmd)
    endf
````
but for shellesc() there is no problem because powershell works like bash and sh, that is, literal strings use '' and within them " do not need to be escaped.