### PR TITLE
fix: The unauthenticated git protocol on port 9418 is no longer supported. 

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -138,10 +138,11 @@ endf
 func! s:parse_name(arg)
   let arg = a:arg
   let git_proto = exists('g:vundle_default_git_proto') ? g:vundle_default_git_proto : 'https'
+  let git_host = git_proto == 'git' ? '@github.com:' : '://github.com/'
 
   if    arg =~? '^\s*\(gh\|github\):\S\+'
   \  || arg =~? '^[a-z0-9][a-z0-9-]*/[^/]\+$'
-    let uri = git_proto.'://github.com/'.split(arg, ':')[-1]
+    let uri = git_proto.git_host.split(arg, ':')[-1]
     if uri !~? '\.git$'
       let uri .= '.git'
     endif
@@ -153,7 +154,7 @@ func! s:parse_name(arg)
     let name = split( substitute(uri,'/\?\.git\s*$','','i') ,'\/')[-1]
   else
     let name = arg
-    let uri  = git_proto.'://github.com/vim-scripts/'.name.'.git'
+    let uri  = git_proto.git_host.'vim-scripts/'.name.'.git'
   endif
   return {'name': name, 'uri': uri, 'name_spec': arg }
 endf


### PR DESCRIPTION
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Change protocal from git to ssh if g:vundle_default_git_proto = 'git'